### PR TITLE
chore: remove loggers ability to write to disk

### DIFF
--- a/pkg/cmd/common/common.go
+++ b/pkg/cmd/common/common.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	cfg "github.com/validator-labs/validatorctl/pkg/config"
-	log "github.com/validator-labs/validatorctl/pkg/logging"
 	embed_utils "github.com/validator-labs/validatorctl/pkg/utils/embed"
 )
 
@@ -16,9 +15,6 @@ func InitWorkspace(c *cfg.Config, workspaceDir string, subdirs []string, timesta
 
 	// Unpack binaries
 	embed_utils.InitBinaries(c)
-
-	// Initialize logger
-	log.SetOutput(c.RunLoc)
 
 	return nil
 }

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -84,8 +84,8 @@ var (
 	HTTPSchemes           = []string{"https://", "http://"}
 
 	// Command dirs
-	BaseDirs         = []string{"bin", "logs"}
-	ValidatorSubdirs = []string{"logs", "manifests"}
+	BaseDirs         = []string{"bin"}
+	ValidatorSubdirs = []string{"manifests"}
 
 	// Validator
 	PlacementTypeStatic  = "Static"

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	logging "log"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -13,19 +12,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// The global logger's standard methods (i.e., log.Infof, log.Debugf, etc.)
-// write log entries to disk.
-//
-//   file location: ~/.validator/logs/validator.log
-//
 // The log.InfoCLI method logs entries to the console. It is used to guide users
 // through an interactive TUI experience.
 
 var (
-	log                 *logrus.Logger
-	cliLog              = pterm.DefaultLogger
-	logFile, statusFile string
-	Newline             = true
+	log     *logrus.Logger
+	cliLog  = pterm.DefaultLogger
+	Newline = true
 )
 
 func init() {
@@ -43,17 +36,6 @@ func SetLevel(logLevel string) {
 		logging.Fatalf("error setting log level: %v", err)
 	}
 	log.SetLevel(level)
-}
-
-func SetOutput(runLoc string) {
-	logFile = filepath.Join(runLoc, "logs", "validator.log")
-	statusFile = filepath.Join(runLoc, "status", "status")
-
-	f, err := os.OpenFile(logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600) //#nosec
-	if err != nil {
-		logging.Fatalf("error opening file: %v", err)
-	}
-	log.SetOutput(f)
 }
 
 // logContext recovers the original caller context of each log message


### PR DESCRIPTION
## Issue
https://github.com/validator-labs/validatorctl/issues/6

## Description
Further simplify the validatorctl by removing the loggers ability to write to disk
