### PR TITLE
feat: ensure no binaries are embedded with validatorctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ HELM_VERSION ?= 3.14.0
 GOLANGCI_VERSION ?= 1.54.2
 KIND_VERSION ?= 0.20.0
 KUBECTL_VERSION ?= 1.24.10
-GH_INSTALL_DIR := $(shell echo $$PATH | tr ':' '\n' | grep -E '^/|^/home|^/usr/local/bin' | head -n 1)
 
 # Product Version
 VERSION_SUFFIX ?= -dev
@@ -152,8 +151,8 @@ docker:
 		@command -v docker >/dev/null 2>&1 || { \
 			echo "Docker not found, downloading..."; \
 			curl -L https://download.docker.com/$(PLATFORM)/static/stable/x86_64/docker-$(DOCKER_VERSION).tgz | tar xz docker/docker; \
-			mv docker/docker $(GH_INSTALL_DIR)/docker; \
-			chmod +x $(GH_INSTALL_DIR)/docker; \
+			mv docker/docker $(RUNNER_TOOL_CACHE)/docker; \
+			chmod +x $(RUNNER_TOOL_CACHE)/docker; \
 			rm -rf ./docker; \
 		} \
 	fi
@@ -162,8 +161,8 @@ kind:
 	@if [ "$(GITHUB_ACTIONS)" = "true" ]; then \
 		@command -v kind >/dev/null 2>&1 || { \
 			echo "Kind not found, downloading..."; \
-			curl -Lo $(GH_INSTALL_DIR)/kind https://github.com/kubernetes-sigs/kind/releases/download/v$(KIND_VERSION)/kind-$(GOOS)-$(GOARCH); \
-			chmod +x $(GH_INSTALL_DIR)/kind; \
+			curl -Lo $(RUNNER_TOOL_CACHE)/kind https://github.com/kubernetes-sigs/kind/releases/download/v$(KIND_VERSION)/kind-$(GOOS)-$(GOARCH); \
+			chmod +x $(RUNNER_TOOL_CACHE)/kind; \
 		} \
 	fi
 
@@ -171,8 +170,8 @@ kubectl:
 	@if [ "$(GITHUB_ACTIONS)" = "true" ]; then \
 		@command -v kubectl >/dev/null 2>&1 || { \
 			echo "Kubectl not found, downloading..."; \
-			curl -Lo $(GH_INSTALL_DIR)/kubectl https://dl.k8s.io/release/v$(KUBECTL_VERSION)/bin/$(GOOS)/$(GOARCH)/kubectl; \
-			chmod +x $(GH_INSTALL_DIR)/kubectl; \
+			curl -Lo $(RUNNER_TOOL_CACHE)/kubectl https://dl.k8s.io/release/v$(KUBECTL_VERSION)/bin/$(GOOS)/$(GOARCH)/kubectl; \
+			chmod +x $(RUNNER_TOOL_CACHE)/kubectl; \
 		} \
 	fi
 
@@ -181,9 +180,9 @@ helm:
 		@command -v helm >/dev/null 2>&1 || { \
 			echo "Helm not found, downloading..."; \
 			curl -L https://get.helm.sh/helm-v$(HELM_VERSION)-$(GOOS)-$(GOARCH).tar.gz | tar xz; \
-			mv $(GOOS)-$(GOARCH)/helm $(GH_INSTALL_DIR)/helm; \
+			mv $(GOOS)-$(GOARCH)/helm $(RUNNER_TOOL_CACHE)/helm; \
 			rm -rf ./$(GOOS)-$(GOARCH); \
-			chmod +x $(GH_INSTALL_DIR)/helm; \
+			chmod +x $(RUNNER_TOOL_CACHE)/helm; \
 		} \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,11 @@ create-images-list: ## Create the image list for CICD
 binaries: docker helm kind kubectl
 
 docker:
+	@echo PATH: $${PATH}
+	@echo RUNNER_TOOL_CACHE: $${RUNNER_TOOL_CACHE}
 	@if [ "$(GITHUB_ACTIONS)" = "true" ]; then \
 		@command -v docker >/dev/null 2>&1 || { \
-			echo "Docker not found, downloading..."; \
+			echo "Docker not found, downloading to $(RUNNER_TOOL_CACHE)/docker..."; \
 			curl -L https://download.docker.com/$(PLATFORM)/static/stable/x86_64/docker-$(DOCKER_VERSION).tgz | tar xz docker/docker; \
 			mv docker/docker $(RUNNER_TOOL_CACHE)/docker; \
 			chmod +x $(RUNNER_TOOL_CACHE)/docker; \
@@ -160,7 +162,7 @@ docker:
 kind:
 	@if [ "$(GITHUB_ACTIONS)" = "true" ]; then \
 		@command -v kind >/dev/null 2>&1 || { \
-			echo "Kind not found, downloading..."; \
+			echo "Kind not found, downloading to $(RUNNER_TOOL_CACHE)/kind..."; \
 			curl -Lo $(RUNNER_TOOL_CACHE)/kind https://github.com/kubernetes-sigs/kind/releases/download/v$(KIND_VERSION)/kind-$(GOOS)-$(GOARCH); \
 			chmod +x $(RUNNER_TOOL_CACHE)/kind; \
 		} \
@@ -169,7 +171,7 @@ kind:
 kubectl:
 	@if [ "$(GITHUB_ACTIONS)" = "true" ]; then \
 		@command -v kubectl >/dev/null 2>&1 || { \
-			echo "Kubectl not found, downloading..."; \
+			echo "Kubectl not found, downloading to $(RUNNER_TOOL_CACHE)/kubectl..."; \
 			curl -Lo $(RUNNER_TOOL_CACHE)/kubectl https://dl.k8s.io/release/v$(KUBECTL_VERSION)/bin/$(GOOS)/$(GOARCH)/kubectl; \
 			chmod +x $(RUNNER_TOOL_CACHE)/kubectl; \
 		} \
@@ -178,7 +180,7 @@ kubectl:
 helm:
 	@if [ "$(GITHUB_ACTIONS)" = "true" ]; then \
 		@command -v helm >/dev/null 2>&1 || { \
-			echo "Helm not found, downloading..."; \
+			echo "Helm not found, downloading to $(RUNNER_TOOL_CACHE)/helm..."; \
 			curl -L https://get.helm.sh/helm-v$(HELM_VERSION)-$(GOOS)-$(GOARCH).tar.gz | tar xz; \
 			mv $(GOOS)-$(GOARCH)/helm $(RUNNER_TOOL_CACHE)/helm; \
 			rm -rf ./$(GOOS)-$(GOARCH); \

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ VERSION ?= 0.0.1${VERSION_SUFFIX}
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 CURRENT_DIR := $(dir $(MAKEFILE_PATH))
 BIN_DIR ?= ./bin
+export PATH := $(PATH):$(RUNNER_TOOL_CACHE)
 
 # Go env vars
 GOOS ?= $(shell go env GOOS)
@@ -147,11 +148,9 @@ create-images-list: ## Create the image list for CICD
 binaries: docker helm kind kubectl
 
 docker:
-	@echo PATH: $${PATH}
-	@echo RUNNER_TOOL_CACHE: $${RUNNER_TOOL_CACHE}
 	@if [ "$(GITHUB_ACTIONS)" = "true" ]; then \
 		@command -v docker >/dev/null 2>&1 || { \
-			echo "Docker not found, downloading to $(RUNNER_TOOL_CACHE)/docker..."; \
+			echo "Docker not found, downloading..."; \
 			curl -L https://download.docker.com/$(PLATFORM)/static/stable/x86_64/docker-$(DOCKER_VERSION).tgz | tar xz docker/docker; \
 			mv docker/docker $(RUNNER_TOOL_CACHE)/docker; \
 			chmod +x $(RUNNER_TOOL_CACHE)/docker; \
@@ -162,7 +161,7 @@ docker:
 kind:
 	@if [ "$(GITHUB_ACTIONS)" = "true" ]; then \
 		@command -v kind >/dev/null 2>&1 || { \
-			echo "Kind not found, downloading to $(RUNNER_TOOL_CACHE)/kind..."; \
+			echo "Kind not found, downloading..."; \
 			curl -Lo $(RUNNER_TOOL_CACHE)/kind https://github.com/kubernetes-sigs/kind/releases/download/v$(KIND_VERSION)/kind-$(GOOS)-$(GOARCH); \
 			chmod +x $(RUNNER_TOOL_CACHE)/kind; \
 		} \
@@ -171,7 +170,7 @@ kind:
 kubectl:
 	@if [ "$(GITHUB_ACTIONS)" = "true" ]; then \
 		@command -v kubectl >/dev/null 2>&1 || { \
-			echo "Kubectl not found, downloading to $(RUNNER_TOOL_CACHE)/kubectl..."; \
+			echo "Kubectl not found, downloading..."; \
 			curl -Lo $(RUNNER_TOOL_CACHE)/kubectl https://dl.k8s.io/release/v$(KUBECTL_VERSION)/bin/$(GOOS)/$(GOARCH)/kubectl; \
 			chmod +x $(RUNNER_TOOL_CACHE)/kubectl; \
 		} \
@@ -180,7 +179,7 @@ kubectl:
 helm:
 	@if [ "$(GITHUB_ACTIONS)" = "true" ]; then \
 		@command -v helm >/dev/null 2>&1 || { \
-			echo "Helm not found, downloading to $(RUNNER_TOOL_CACHE)/helm..."; \
+			echo "Helm not found, downloading..."; \
 			curl -L https://get.helm.sh/helm-v$(HELM_VERSION)-$(GOOS)-$(GOARCH).tar.gz | tar xz; \
 			mv $(GOOS)-$(GOARCH)/helm $(RUNNER_TOOL_CACHE)/helm; \
 			rm -rf ./$(GOOS)-$(GOARCH); \

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	cfg "github.com/validator-labs/validatorctl/pkg/config"
 	cfgmanager "github.com/validator-labs/validatorctl/pkg/config/manager"
 	log "github.com/validator-labs/validatorctl/pkg/logging"
+	exec_utils "github.com/validator-labs/validatorctl/pkg/utils/exec"
 )
 
 var (
@@ -52,6 +53,11 @@ Use 'validator help <sub-command>' to explore all of the functionality the Valid
 	globalFlags.StringVarP(&workspaceLoc, "workspace", "w", "", `Workspace location for staging runtime configurations and logs (default "$HOME/.validator")`)
 
 	if err := viper.BindPFlag("logLevel", globalFlags.Lookup("log-level")); err != nil {
+		exit(err)
+	}
+
+	// Verify required binaries exist
+	if err := exec_utils.CheckBinaries(); err != nil {
 		exit(err)
 	}
 

--- a/pkg/cmd/common/common.go
+++ b/pkg/cmd/common/common.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	cfg "github.com/validator-labs/validatorctl/pkg/config"
-	embed_utils "github.com/validator-labs/validatorctl/pkg/utils/embed"
 )
 
 func InitWorkspace(c *cfg.Config, workspaceDir string, subdirs []string, timestamped bool) error {
@@ -12,9 +11,5 @@ func InitWorkspace(c *cfg.Config, workspaceDir string, subdirs []string, timesta
 	if err := c.CreateWorkspace(workspaceDir, subdirs, timestamped); err != nil {
 		return fmt.Errorf("failed to initialize workspace: %v", err)
 	}
-
-	// Unpack binaries
-	embed_utils.InitBinaries(c)
-
 	return nil
 }

--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -24,7 +24,8 @@ import (
 	cfg "github.com/validator-labs/validatorctl/pkg/config"
 	log "github.com/validator-labs/validatorctl/pkg/logging"
 	"github.com/validator-labs/validatorctl/pkg/services/validator"
-	embed "github.com/validator-labs/validatorctl/pkg/utils/embed"
+	embed_utils "github.com/validator-labs/validatorctl/pkg/utils/embed"
+	exec_utils "github.com/validator-labs/validatorctl/pkg/utils/exec"
 	"github.com/validator-labs/validatorctl/pkg/utils/kind"
 	"github.com/validator-labs/validatorctl/pkg/utils/kube"
 )
@@ -210,7 +211,7 @@ func buildValidationResultString(vrObj unstructured.Unstructured) (string, error
 		"Values": vals,
 	}
 
-	if err := embed.PrintTableTemplate(sb, args, cfg.Validator, "validation-result.tmpl"); err != nil {
+	if err := embed_utils.PrintTableTemplate(sb, args, cfg.Validator, "validation-result.tmpl"); err != nil {
 		return "", err
 	}
 
@@ -221,7 +222,7 @@ func buildValidationResultString(vrObj unstructured.Unstructured) (string, error
 			"Values": []string{c.ValidationRule, c.ValidationType, string(c.Status), c.LastValidationTime.Format(time.RFC3339), strings.TrimSpace(c.Message)},
 		}
 
-		if err := embed.PrintTableTemplate(sb, args, cfg.Validator, "validation-result.tmpl"); err != nil {
+		if err := embed_utils.PrintTableTemplate(sb, args, cfg.Validator, "validation-result.tmpl"); err != nil {
 			return "", err
 		}
 
@@ -294,7 +295,7 @@ func applyValidator(c *cfg.Config, vc *components.ValidatorConfig) error {
 			"Config":        vc.AWSPlugin,
 			"ImageRegistry": vc.ImageRegistry,
 		}
-		values, err := embed.RenderTemplateBytes(args, cfg.Validator, "validator-plugin-aws-values.tmpl")
+		values, err := embed_utils.RenderTemplateBytes(args, cfg.Validator, "validator-plugin-aws-values.tmpl")
 		if err != nil {
 			return errors.Wrap(err, "failed to render validator plugin aws values.yaml")
 		}
@@ -313,7 +314,7 @@ func applyValidator(c *cfg.Config, vc *components.ValidatorConfig) error {
 			"Config":        vc.AzurePlugin,
 			"ImageRegistry": vc.ImageRegistry,
 		}
-		values, err := embed.RenderTemplateBytes(args, cfg.Validator, "validator-plugin-azure-values.tmpl")
+		values, err := embed_utils.RenderTemplateBytes(args, cfg.Validator, "validator-plugin-azure-values.tmpl")
 		if err != nil {
 			return errors.Wrap(err, "failed to render validator plugin azure values.yaml")
 		}
@@ -332,7 +333,7 @@ func applyValidator(c *cfg.Config, vc *components.ValidatorConfig) error {
 			"Tag":           vc.NetworkPlugin.Release.Chart.Version,
 			"ImageRegistry": vc.ImageRegistry,
 		}
-		values, err := embed.RenderTemplateBytes(args, cfg.Validator, "validator-plugin-network-values.tmpl")
+		values, err := embed_utils.RenderTemplateBytes(args, cfg.Validator, "validator-plugin-network-values.tmpl")
 		if err != nil {
 			return errors.Wrap(err, "failed to render validator plugin network values.yaml")
 		}
@@ -351,7 +352,7 @@ func applyValidator(c *cfg.Config, vc *components.ValidatorConfig) error {
 			"Config":        vc.OCIPlugin,
 			"ImageRegistry": vc.ImageRegistry,
 		}
-		values, err := embed.RenderTemplateBytes(args, cfg.Validator, "validator-plugin-oci-values.tmpl")
+		values, err := embed_utils.RenderTemplateBytes(args, cfg.Validator, "validator-plugin-oci-values.tmpl")
 		if err != nil {
 			return errors.Wrap(err, "failed to render validator plugin oci values.yaml")
 		}
@@ -370,7 +371,7 @@ func applyValidator(c *cfg.Config, vc *components.ValidatorConfig) error {
 			"Config":        vc.VspherePlugin,
 			"ImageRegistry": vc.ImageRegistry,
 		}
-		values, err := embed.RenderTemplateBytes(args, cfg.Validator, "validator-plugin-vsphere-values.tmpl")
+		values, err := embed_utils.RenderTemplateBytes(args, cfg.Validator, "validator-plugin-vsphere-values.tmpl")
 		if err != nil {
 			return errors.Wrap(err, "failed to render validator plugin vsphere values.yaml")
 		}
@@ -403,7 +404,7 @@ func applyValidator(c *cfg.Config, vc *components.ValidatorConfig) error {
 		args["ProxyCaCertData"] = strings.Split(vc.ProxyConfig.Env.ProxyCaCertData, "\n")
 	}
 
-	values, err := embed.RenderTemplateBytes(args, cfg.Validator, "validator-base-values.tmpl")
+	values, err := embed_utils.RenderTemplateBytes(args, cfg.Validator, "validator-base-values.tmpl")
 	if err != nil {
 		return errors.Wrap(err, "failed to render validator base values.yaml")
 	}
@@ -506,7 +507,7 @@ func getHelmClient(vc *components.ValidatorConfig) (helm.HelmClient, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get API config from kubeconfig")
 	}
-	helm.CommandPath = embed.Helm
+	helm.CommandPath = exec_utils.Helm
 	helmClient := helm.NewHelmClient(apiCfg)
 	return helmClient, nil
 }
@@ -536,7 +537,7 @@ func applyPlugins(c *cfg.Config, vc *components.ValidatorConfig) error {
 				"Auth":        indent(auth, 4),
 				"IamRoleName": vc.AWSPlugin.IamCheck.IamRoleName,
 			}
-			if err := embed.RenderTemplate(args, cfg.Validator, template, outputPath); err != nil {
+			if err := embed_utils.RenderTemplate(args, cfg.Validator, template, outputPath); err != nil {
 				return err
 			}
 			if err := applyValidatorManifest(vc.Kubeconfig, cfg.ValidatorPluginAws, outputPath); err != nil {
@@ -595,7 +596,7 @@ func createValidator(kubeconfig, runLoc, name, template string, validator interf
 		"Spec":      indent(spec, 2),
 	}
 	path := filepath.Join(runLoc, "manifests", fmt.Sprintf("%s.yaml", name))
-	if err := embed.RenderTemplate(args, cfg.Validator, template, path); err != nil {
+	if err := embed_utils.RenderTemplate(args, cfg.Validator, template, path); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to render %s validator manifest", name))
 	}
 	return applyValidatorManifest(kubeconfig, name, path)

--- a/pkg/utils/embed/embed.go
+++ b/pkg/utils/embed/embed.go
@@ -3,68 +3,17 @@ package embed
 import (
 	"bytes"
 	"embed"
+
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
-	"runtime"
 	"text/tabwriter"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
 
-	cfg "github.com/validator-labs/validatorctl/pkg/config"
 	log "github.com/validator-labs/validatorctl/pkg/logging"
 )
-
-var Docker, Helm, Kind, Kubectl string
-
-//go:embed bin/docker
-var docker []byte
-
-//go:embed bin/helm
-var helm []byte
-
-//go:embed bin/kind
-var kind []byte
-
-//go:embed bin/kubectl
-var kubectl []byte
-
-func InitBinaries(c *cfg.Config) {
-	if runtime.GOOS == "windows" {
-		Docker = filepath.Join(c.WorkspaceLoc, "bin", "docker.exe")
-		Helm = filepath.Join(c.WorkspaceLoc, "bin", "helm.exe")
-		Kind = filepath.Join(c.WorkspaceLoc, "bin", "kind.exe")
-		Kubectl = filepath.Join(c.WorkspaceLoc, "bin", "kubectl.exe")
-	} else {
-		Docker = filepath.Join(c.WorkspaceLoc, "bin", "docker")
-		Helm = filepath.Join(c.WorkspaceLoc, "bin", "helm")
-		Kind = filepath.Join(c.WorkspaceLoc, "bin", "kind")
-		Kubectl = filepath.Join(c.WorkspaceLoc, "bin", "kubectl")
-	}
-
-	if _, err := os.Stat(Docker); os.IsNotExist(err) {
-		if err := os.WriteFile(Docker, docker, 0755); err != nil /* #nosec G306 */ {
-			log.FatalCLI(err.Error())
-		}
-	}
-	if _, err := os.Stat(Helm); os.IsNotExist(err) {
-		if err := os.WriteFile(Helm, helm, 0755); err != nil /* #nosec G306 */ {
-			log.FatalCLI(err.Error())
-		}
-	}
-	if _, err := os.Stat(Kind); os.IsNotExist(err) {
-		if err := os.WriteFile(Kind, kind, 0755); err != nil /* #nosec G306 */ {
-			log.FatalCLI(err.Error())
-		}
-	}
-	if _, err := os.Stat(Kubectl); os.IsNotExist(err) {
-		if err := os.WriteFile(Kubectl, kubectl, 0755); err != nil /* #nosec G306 */ {
-			log.FatalCLI(err.Error())
-		}
-	}
-}
 
 //go:embed resources/*
 var resources embed.FS

--- a/pkg/utils/embed/embed.go
+++ b/pkg/utils/embed/embed.go
@@ -3,7 +3,6 @@ package embed
 import (
 	"bytes"
 	"embed"
-
 	"fmt"
 	"io"
 	"os"

--- a/pkg/utils/exec/exec.go
+++ b/pkg/utils/exec/exec.go
@@ -2,14 +2,47 @@ package exec
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os/exec"
 
 	log "github.com/validator-labs/validatorctl/pkg/logging"
 )
 
-// Execute enables monkey-patching cmd execution for integration tests
-var Execute = execute
+var (
+	// Execute enables monkey-patching cmd execution for integration tests
+	Execute                     = execute
+	Docker, Helm, Kind, Kubectl string
+)
+
+func CheckBinaries() error {
+	binaries := []struct {
+		name string
+		path *string
+	}{
+		{"docker", &Docker},
+		{"helm", &Helm},
+		{"kind", &Kind},
+		{"kubectl", &Kubectl},
+	}
+
+	hasAllBinaries := true
+
+	for _, binary := range binaries {
+		path, err := exec.LookPath(binary.name)
+		if err != nil {
+			hasAllBinaries = false
+			log.ErrorCLI(fmt.Sprintf("%s is not installed or not in your PATH. Please install %s.", binary.name, binary.name))
+		}
+		*binary.path = path
+	}
+
+	if !hasAllBinaries {
+		return fmt.Errorf("missing required binaries")
+	}
+
+	return nil
+}
 
 type WriterStringer interface {
 	String() string

--- a/pkg/utils/exec/exec.go
+++ b/pkg/utils/exec/exec.go
@@ -32,7 +32,7 @@ func CheckBinaries() error {
 		path, err := exec.LookPath(binary.name)
 		if err != nil {
 			hasAllBinaries = false
-			log.ErrorCLI(fmt.Sprintf("%s is not installed or not in your PATH. Please install %s.", binary.name, binary.name))
+			log.ErrorCLI(fmt.Sprintf("%s is not installed.\nPlease install the missing dependency and ensure it's available on your PATH.", binary.name))
 		}
 		*binary.path = path
 	}

--- a/pkg/utils/kind/kind.go
+++ b/pkg/utils/kind/kind.go
@@ -50,7 +50,7 @@ func StartCluster(name, kindConfig, kubeconfig string) error {
 		"create", "cluster", "--name", name,
 		"--kubeconfig", kubeconfig, "--config", kindConfig,
 	}
-	cmd := exec.Command(embed_utils.Kind, args...) //#nosec G204
+	cmd := exec.Command(exec_utils.Kind, args...) //#nosec G204
 	_, stderr, err := exec_utils.Execute(true, cmd)
 	if err != nil {
 		return errors.Wrap(err, stderr)
@@ -67,7 +67,7 @@ func StartCluster(name, kindConfig, kubeconfig string) error {
 
 func DeleteCluster(name string) error {
 	args := []string{"delete", "cluster", "--name", name}
-	cmd := exec.Command(embed_utils.Kind, args...) //#nosec G204
+	cmd := exec.Command(exec_utils.Kind, args...) //#nosec G204
 	_, stderr, err := exec_utils.Execute(false, cmd)
 	if err != nil {
 		return errors.Wrap(err, stderr)
@@ -99,7 +99,7 @@ func AdvancedConfig(env *env.Env, kindConfig string) error {
 }
 
 func getClusters() ([]string, error) {
-	cmd := exec.Command(embed_utils.Kind, "get", "clusters") //#nosec G204
+	cmd := exec.Command(exec_utils.Kind, "get", "clusters") //#nosec G204
 
 	stdout, stderr, err := exec_utils.Execute(false, cmd)
 	if err != nil {
@@ -127,7 +127,7 @@ func updateCaCerts(name string) error {
 		"exec", fmt.Sprintf("%s-control-plane", name),
 		"sh", "-c", "update-ca-certificates && systemctl restart containerd",
 	}
-	cmd := exec.Command(embed_utils.Docker, args...) //#nosec G204
+	cmd := exec.Command(exec_utils.Docker, args...) //#nosec G204
 	_, stderr, err := exec_utils.Execute(true, cmd)
 	if err != nil {
 		return errors.Wrap(err, stderr)

--- a/pkg/utils/kube/kube.go
+++ b/pkg/utils/kube/kube.go
@@ -17,7 +17,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	log "github.com/validator-labs/validatorctl/pkg/logging"
-	embed_utils "github.com/validator-labs/validatorctl/pkg/utils/embed"
 	exec_utils "github.com/validator-labs/validatorctl/pkg/utils/exec"
 )
 
@@ -31,7 +30,7 @@ type Crd string
 
 func KubectlCommand(params []string, kConfig string) (out, stderr string, err error) {
 	params = append(params, fmt.Sprintf("--kubeconfig=%s", kConfig))
-	cmd := exec.Command(embed_utils.Kubectl, params...) //#nosec
+	cmd := exec.Command(exec_utils.Kubectl, params...) //#nosec
 
 	if slices.Contains(params, "secret") {
 		log.InfoCLI("\n==== Kubectl Command ==== Create Secret")


### PR DESCRIPTION
## Issue
https://github.com/validator-labs/validatorctl/issues/2

## Description
- Updates Makefile to not install binary dependencies (docker, helm, kind, kubectl), unless the test job is being run from gha
- Update CLI to verify that users already have these dependencies installed
  - If any binary is not installed, print an error message with the missing binary and exit