### PR TITLE
refactor: ensure int. tests succeed w/ a non-dev CLI version

### DIFF
--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -28,6 +28,7 @@ import (
 	exec_utils "github.com/validator-labs/validatorctl/pkg/utils/exec"
 	"github.com/validator-labs/validatorctl/pkg/utils/kind"
 	"github.com/validator-labs/validatorctl/pkg/utils/kube"
+	string_utils "github.com/validator-labs/validatorctl/pkg/utils/string"
 )
 
 func DeployValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig, reconfigure bool) error {
@@ -69,7 +70,7 @@ func DeployValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig, reconfigure bool)
 
 		// for dev build versions, we allow selection of specific validator and plugin versions
 		// for all other builds, we set a fixed version for the validator and plugins
-		vc.UseFixedVersions = !strings.HasSuffix(tc.CliVersion, "-dev")
+		vc.UseFixedVersions = !string_utils.IsDevVersion(tc.CliVersion)
 		if err := validator.ReadValidatorConfig(c, tc, vc); err != nil {
 			return errors.Wrap(err, "failed to create new validator configuration")
 		}

--- a/pkg/utils/string/string.go
+++ b/pkg/utils/string/string.go
@@ -23,6 +23,13 @@ func MultiTrim(str string, prefixes, suffixes []string) string {
 	return str
 }
 
+// RandStr generates a random string of a given length, which is the first
+// N chars of a UUID of the form: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx, per RFC4122.
 func RandStr(len int) string {
 	return uuid.NewString()[:len]
+}
+
+// IsDevVersion checks if a given CLI version is a development version.
+func IsDevVersion(cliVersion interface{}) bool {
+	return strings.HasSuffix(cliVersion.(string), "-dev")
 }

--- a/tests/integration/_validator/executor.go
+++ b/tests/integration/_validator/executor.go
@@ -8,12 +8,11 @@ import (
 	"github.com/validator-labs/validatorctl/tests/utils/test"
 )
 
-func Execute() error {
+func Execute(ctx *test.TestContext) error {
 	log.Printf("-----------------------------------")
 	log.Printf("--------- Validator Suite ----------")
 	log.Printf("-----------------------------------")
-	testCtx := test.NewTestContext()
-	return test.Flow(testCtx).
+	return test.Flow(ctx).
 		Test(common.NewSingleFuncTest("validator-test", validator.Execute)).
 		Summarize().TearDown().Audit()
 }

--- a/tests/integration/_validator/testcases/data/validator.yaml
+++ b/tests/integration/_validator/testcases/data/validator.yaml
@@ -4,7 +4,6 @@ helmRelease:
     repository: https://validator-labs.github.io/validator
     version: v0.0.42
     insecureSkipVerify: true
-    authSecretName: ""
   values: ""
 helmReleaseSecret:
   name: ""
@@ -24,10 +23,10 @@ sinkConfig:
   type: alertmanager
   values:
     caCert: ""
-    endpoint: q+spTX7QL7D2iaABq1SDQg+FBmnaaaa4zLytubci/s5H4kx+Bbj0unAs6kQ=
-    insecureSkipVerify: uZQG4MNdiAPEzURxQHfNHp9ygog=
-    password: PzBy0KPtFodrWa1cEHdJPcFNDA==
-    username: TRsBYLFEIPTsChLHhZ5gQ04T0A==
+    endpoint: jpumctAu1P2XrbMtcBmSlZPTtSk1/mOMt2Njxf/HH5bZc/cBkdrPDLnh9hs=
+    insecureSkipVerify: 1F49dw3qWQrlk5KqKBgJfQPcbGc=
+    password: DbrMXgDDv3RUAI4aUDhawf+Wtw==
+    username: OmVfeZPe1Va+S2K6BuaURChRQg==
 proxyConfig:
   enabled: false
   env:
@@ -41,7 +40,6 @@ awsPlugin:
       repository: https://validator-labs.github.io/validator-plugin-aws
       version: v0.0.26
       insecureSkipVerify: true
-      authSecretName: ""
     values: ""
   helmReleaseSecret:
     name: ""
@@ -49,8 +47,8 @@ awsPlugin:
     password: ""
     caCertFile: ""
     exists: false
-  accessKeyId: 620wDlsK6+snySwYVJsYQ5y/QDB6O6tZag==
-  secretAccessKey: ds9SF9V2pjisCXlN006oGpGacGOzi2CQwExdQ9GrIA==
+  accessKeyId: a0XCQd+Emx7/bwAaTyY13ipTRychb4MiQw==
+  secretAccessKey: IrGIW8FPVuOxVDRWQUdTa22SDf1MQ2PBw0kdngVq+w==
   iamCheck:
     enabled: true
     iamRoleName: SpectroCloudRole
@@ -87,7 +85,6 @@ networkPlugin:
       repository: https://validator-labs.github.io/validator-plugin-network
       version: v0.0.17
       insecureSkipVerify: true
-      authSecretName: ""
     values: ""
   helmReleaseSecret:
     name: ""
@@ -130,12 +127,10 @@ ociPlugin:
     password: ""
     caCertFile: ""
     exists: false
-  caCertPaths:
-    0: ""
   secrets:
   - name: oci-creds
     username: user1
-    password: 7l5W16YPPFqeSsu2PFzBGSOrtJ2k+pV5
+    password: VE74qaSN2qFqBJifybU/Dy/lceRliQGC
     caCertFile: ""
     exists: false
   publicKeySecrets:
@@ -146,6 +141,8 @@ ociPlugin:
       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKPuCo9AmJCpqGWhefjbhkFcr1GA3
       iNa765seE3jYC3MGUe5h52393Dhy7B5bXGsg6EfPpNYamlAEWjxCpHF3Lg==
       -----END PUBLIC KEY-----
+  caCertPaths:
+    0: ""
   validator:
     ociRegistryRules:
     - name: public ecr registry
@@ -160,7 +157,6 @@ vspherePlugin:
       repository: https://validator-labs.github.io/validator-plugin-vsphere
       version: v0.0.23
       insecureSkipVerify: true
-      authSecretName: ""
     values: ""
   helmReleaseSecret:
     name: ""
@@ -170,7 +166,7 @@ vspherePlugin:
     exists: false
   account:
     insecure: true
-    password: ui8+y8gIDE3fbRphEolkQxS62QjvxQYk
+    password: vn0cCP3U08iqDUwwCgBFWBbfekA+4TTe
     username: bob@vsphere.com
     vcenterServer: fake.vsphere.com
   validator:
@@ -463,7 +459,6 @@ azurePlugin:
       repository: https://validator-labs.github.io/validator-plugin-azure
       version: v0.0.11
       insecureSkipVerify: true
-      authSecretName: ""
     values: ""
   helmReleaseSecret:
     name: ""
@@ -473,7 +468,7 @@ azurePlugin:
     exists: false
   tenantId: d551b7b1-78ae-43df-9d61-4935c843a454
   clientId: d551b7b1-78ae-43df-9d61-4935c843a454
-  clientSecret: hzcbAP2T+YOJCVQ/FCihRD7H9Xx/n58sQBG+cYavnCv/wg==
+  clientSecret: qC9aFbiDg/O2Ef31aqEBrbYXb/I+t+qXA4swfguuEBRRAQ==
   ruleTypes:
     0: Cluster Deployment
     1: Cluster Deployment

--- a/tests/integration/_validator/testcases/test_validator.go
+++ b/tests/integration/_validator/testcases/test_validator.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"slices"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spectrocloud-labs/prompts-tui/prompts"
@@ -21,9 +22,8 @@ import (
 
 var kindClusterName string
 
-func Execute() error {
-	testCtx := test.NewTestContext()
-	return test.Flow(testCtx).
+func Execute(ctx *test.TestContext) error {
+	return test.Flow(ctx).
 		Test(NewValidatorTest("validator-integration-test")).
 		TearDown().Audit()
 }
@@ -95,242 +95,300 @@ func (t *ValidatorTest) testDeployInteractive(ctx *test.TestContext) (tr *test.T
 		return vsphereDriverMock, nil
 	}
 
-	prompts.Tui = &tuimocks.MockTUI{
-		ReturnVals: []string{
-			// Kind
-			"y", // provision & use kind cluster
+	// Base config
+	tuiVals := []string{
+		// Kind
+		"y", // provision & use kind cluster
 
-			// Image registry
-			"quay.io/validator-labs", // validator image registry
+		// Image registry
+		"quay.io/validator-labs", // validator image registry
 
-			// Proxy
-			"n", // Configure an HTTP proxy
+		// Proxy
+		"n", // Configure an HTTP proxy
 
-			// Sink
-			"y",                            // Configure a sink
-			"Alertmanager",                 // Sink type
-			"sink-secret",                  // Sink secret name
-			"https://alertmanager.io:9093", // Alertmanager endpoint
-			"y",                            // Alertmanager insecureSkipVerify
-			"foo",                          // Alertmanager username
-			"bar",                          // Alertmanager password
-
-			// Helm repo
-			cfg.ValidatorHelmRepository,               // validator helm chart repo
-			cfg.ValidatorChartVersions[cfg.Validator], // validator helm chart version
-			"y",   // insecure skip verify
-			"y",   // use basic auth
-			"bob", // release secret username
-			"dog", // release secret password
-
-			// AWS plugin
-			"y",                         // enable AWS plugin
-			cfg.ValidatorHelmRepository, // validator-plugin-aws helm chart repo
-			cfg.ValidatorChartVersions[cfg.ValidatorPluginAws], // validator-plugin-aws helm chart version
-			"y",                   // Re-use validator chart security configuration
-			"n",                   // use implicit auth
-			"aws-creds",           // AWS secret name
-			"secretkey",           // AWS Secret Key ID
-			"secretaccesskey",     // AWS Secret Access Key
-			"",                    // AWS Session Token
-			"y",                   // Configure STS
-			"arn",                 // AWS STS Role Arn
-			"abc",                 // AWS STS Session Name
-			"3600",                // AWS STS Duration Seconds
-			"us-west-2",           // default region
-			"y",                   // enable IAM validation
-			"SpectroCloudRole",    // IAM role name
-			"Base",                // IAM check type
-			"y",                   // enable service quota validation
-			"EC2",                 // rule name
-			"EC2-VPC Elastic IPs", // service quota type
-			"us-west-2",           // service quota region #1
-			"5",                   // service quota buffer #1
-			"n",                   // add another service quota rule
-			"y",                   // enable subnet tag validation
-			"subnet",              // tag resource type
-			"elb tag rule",        // rule name
-			"us-west-2",           // subnet tag region #1
-			"foo",                 // subnet tag key #1
-			"bar",                 // subnet tag value #1
-			"baz",                 // subnet arn #1
-			"n",                   // add another subnet arn
-			"n",                   // add another subnet tag rule
-			"n",                   // add another tag rule
-
-			// Azure plugin
-			"y",                         // enable plugin
-			cfg.ValidatorHelmRepository, // helm chart repo
-			cfg.ValidatorChartVersions[cfg.ValidatorPluginAzure], // helm chart version
-			"n",                                    // Re-use validator chart security configuration
-			"y",                                    // insecure skip verify
-			"n",                                    // use basic auth
-			"n",                                    // implicit plugin auth
-			"azure-creds",                          // k8s secret name
-			"d551b7b1-78ae-43df-9d61-4935c843a454", // tenant id
-			"d551b7b1-78ae-43df-9d61-4935c843a454", // client id
-			"test_client_secret",                   // client secret
-			"Cluster Deployment",                   // rule type (select)
-			"Static",                               // placement type (select)
-			"Single cluster",                       // static deployment style (select)
-			"rule-1",                               // rule name
-			"d551b7b1-78ae-43df-9d61-4935c843a454", // service principal
-			"d551b7b1-78ae-43df-9d61-4935c843a454", // subscription
-			"rg",                                   // resource group
-			"vn",                                   // virtual network
-			"s",                                    // subnet
-			"acg",                                  // azure compute gallery
-			"y",                                    // add RBAC rule
-			"Cluster Deployment",                   // rule type (select)
-			"Static",                               // placement type (select)
-			"Multiple clusters in a single resource group", // static deployment style (select)
-			"rule-2",                               // rule name
-			"d551b7b1-78ae-43df-9d61-4935c843a454", // service principal
-			"d551b7b1-78ae-43df-9d61-4935c843a454", // subscription
-			"rg",                                   // resource group
-			"y",                                    // add RBAC rule
-			"Cluster Deployment",                   // rule type (select)
-			"Static",                               // placement type (select)
-			"Multiple clusters in a single subscription", // static deployment style (select)
-			"rule-3",                               // rule name
-			"d551b7b1-78ae-43df-9d61-4935c843a454", // service principal
-			"d551b7b1-78ae-43df-9d61-4935c843a454", // subscription
-			"y",                                    // add RBAC rule
-			"Cluster Deployment",                   // rule type (select)
-			"Dynamic",                              // placement type (select)
-			"rule-4",                               // rule name
-			"d551b7b1-78ae-43df-9d61-4935c843a454", // service principal
-			"d551b7b1-78ae-43df-9d61-4935c843a454", // subscription
-			"y",                                    // add RBAC rule
-			"Custom",                               // rule type (select)
-			"rule-5",                               // rule name
-			"d551b7b1-78ae-43df-9d61-4935c843a454", // security principal
-			"s",                                    // scope
-			"a",                                    // Action
-			"n",                                    // add Action
-			"da",                                   // DataAction
-			"n",                                    // add DataAction
-			"n",                                    // add permission set
-			"n",                                    // add RBAC rule
-
-			// Network plugin
-			"y",                         // enable Network plugin
-			cfg.ValidatorHelmRepository, // validator-plugin-network helm chart repo
-			cfg.ValidatorChartVersions[cfg.ValidatorPluginNetwork], // validator-plugin-network helm chart version
-			"y",           // Re-use validator chart security configuration
-			"y",           // enable DNS validation
-			"resolve foo", // DNS rule name
-			"foo",         // DNS host
-			"",            // DNS nameserver
-			"n",           // add another DNS rule
-			"y",           // enable ICMP validation
-			"ping foo",    // ICMP rule name
-			"foo",         // ICMP host
-			"n",           // add another ICMP rule
-			"y",           // enable IP range validation
-			"check ips",   // IP range rule name
-			"10.10.10.10", // first IPv4 in range
-			"10",          // length of IPv4 range
-			"n",           // add another IP range rule
-			"y",           // enable MTU validation
-			"check mtu",   // MTU rule name
-			"foo",         // MTU host
-			"1500",        // minimum MTU
-			"n",           // add another MTU rule
-			"y",           // enable TCP connection validation
-			"check tcp",   // TCP connection rule name
-			"foo",         // TCP connection host
-			"80",          // TCP connection port
-			"n",           // add another port
-			"n",           // add another TCP connection rule
-
-			// OCI plugin
-			"y",                         // enable OCI plugin
-			cfg.ValidatorHelmRepository, // validator-plugin-oci helm chart repo
-			cfg.ValidatorChartVersions[cfg.ValidatorPluginOci], // validator-plugin-oci helm chart version
-			"y",                        // Re-use validator chart security configuration
-			"y",                        // add registry credentials
-			"oci-creds",                // secret name
-			"user1",                    // username
-			"pa$$w0rd",                 // password
-			"n",                        // add another registry credential
-			"y",                        // add signature verification secret
-			"cosign-pubkeys",           // secret name
-			t.filePath("cosign.pub"),   // public key file
-			"n",                        // add another public key to this secret
-			"n",                        // add another signature verification secret
-			"public ecr registry",      // rule name
-			"public.ecr.aws",           // registry host
-			"N/A",                      // registry auth secret name
-			"u5n5j0b4/oci-test-public", // artifact ref
-			"n",                        // enable full layer validation
-			"n",                        // add another artifact
-			"N/A",                      // signature verification secret name
-			"",                         // ca certificate
-			"n",                        // add another registry rule
-
-			// vSphere plugin
-			"y",                         // enable vsphere plugin
-			cfg.ValidatorHelmRepository, // validator-plugin-vsphere helm chart repo
-			cfg.ValidatorChartVersions[cfg.ValidatorPluginVsphere], // validator-plugin-vsphere helm chart version
-			"y",                                // Re-use validator chart security configuration
-			"vsphere-creds",                    // vSphere secret name
-			"fake.vsphere.com",                 // vSphere domain
-			"bob@vsphere.com",                  // vSphere username
-			"password",                         // vSphere password
-			"y",                                // insecure skip verify
-			"DC0",                              // datacenter
-			"y",                                // Enable NTP check
-			"ntpd",                             // NTP rule name
-			"y",                                // are hosts cluster scoped
-			"C0",                               // cluster name
-			"DC0_C0_H0",                        // host1
-			"y",                                // add more hosts
-			"DC0_C0_H1",                        // host2
-			"n",                                // add more hosts
-			"n",                                // add more validation rules
-			"y",                                // Check role privileges
-			"role rule 1",                      // Role privilege rule name
-			"user1@vsphere.local",              // user to check role privileges against
-			cfg.SpectroRootLevelPrivilegesV7_0, // vSphere permission version
-			"n",                                // add more role privilege checks
-			"y",                                // check entity privileges
-			"entity rule 1",                    // entity privilege rule name
-			cfg.SpectroEntityPrivileges,        // entity level permissions
-			"Read folder: spectro-templates",   // spectro entity permission
-			"user2@vsphere.local",              // user to check entity privileges against
-			"n",                                // add more entity permission checks
-			"y",                                // check compute resource requirements
-			"resource requirement rule 1",      // resource requirement rule name
-			"Cluster",                          // select cluster for resource check
-			"C0",                               // cluster name for resource check
-			"master-pool",                      // node pool name
-			"1",                                // number of nodes
-			"2GHz",                             // per node cpu
-			"4Gi",                              // per node memory
-			"10Gi",                             // per node storage
-			"y",                                // add another node pool
-			"worker-pool",                      // node pool name
-			"3",                                // number of nodes
-			"3GHz",                             // per node cpu
-			"8Gi",                              // per node memory
-			"20Gi",                             // per node storage
-			"n",                                // add more node pools
-			"n",                                // add more resource requirement checks
-			"y",                                // check tags on entities
-			"tag rule 1",                       // tag rule name
-			cfg.SpectroCloudTags,               // zone & region tags
-			"Cluster: k8s-zone (ensure that the selected cluster has a 'k8s-zone' tag)", // zone tag
-			"C0", // cluster name
-			"n",  // add another tag rule
-
-			// Finalization
-			"n", // restart configuration
-			"n", // reconfigure plugin(s)
-		},
+		// Sink
+		"y",                            // Configure a sink
+		"Alertmanager",                 // Sink type
+		"sink-secret",                  // Sink secret name
+		"https://alertmanager.io:9093", // Alertmanager endpoint
+		"y",                            // Alertmanager insecureSkipVerify
+		"foo",                          // Alertmanager username
+		"bar",                          // Alertmanager password
 	}
 
+	tuiVals = t.baseHelmValues(ctx, tuiVals)
+	tuiVals = t.awsPluginValues(ctx, tuiVals)
+	tuiVals = t.azurePluginValues(ctx, tuiVals)
+	tuiVals = t.networkPluginValues(ctx, tuiVals)
+	tuiVals = t.ociPluginValues(ctx, tuiVals)
+	tuiVals = t.vspherePluginValues(ctx, tuiVals)
+
+	// Finalization
+	tuiVals = append(tuiVals, []string{
+		"n", // restart configuration
+		"n", // reconfigure plugin(s)
+	}...)
+
+	prompts.Tui = &tuimocks.MockTUI{ReturnVals: tuiVals}
+
 	return common.ExecCLI(interactiveCmd, buffer, t.log)
+}
+
+func (t *ValidatorTest) baseHelmValues(ctx *test.TestContext, tuiVals []string) []string {
+	tuiVals = append(tuiVals, []string{
+		cfg.ValidatorHelmRepository, // validator helm chart repo
+		"y",                         // insecure skip verify
+		"y",                         // use basic auth
+		"bob",                       // release secret username
+		"dog",                       // release secret password
+	}...)
+	if string_utils.IsDevVersion(ctx.Get("version")) {
+		tuiVals = slices.Insert(tuiVals, 1,
+			cfg.ValidatorChartVersions[cfg.Validator], // validator helm chart version
+		)
+	}
+	return tuiVals
+}
+
+func (t *ValidatorTest) awsPluginValues(ctx *test.TestContext, tuiVals []string) []string {
+	tuiVals = append(tuiVals, []string{
+		"y",                         // enable AWS plugin
+		cfg.ValidatorHelmRepository, // validator-plugin-aws helm chart repo
+		"y",                         // Re-use validator chart security configuration
+		"n",                         // use implicit auth
+		"aws-creds",                 // AWS secret name
+		"secretkey",                 // AWS Secret Key ID
+		"secretaccesskey",           // AWS Secret Access Key
+		"",                          // AWS Session Token
+		"y",                         // Configure STS
+		"arn",                       // AWS STS Role Arn
+		"abc",                       // AWS STS Session Name
+		"3600",                      // AWS STS Duration Seconds
+		"us-west-2",                 // default region
+		"y",                         // enable IAM validation
+		"SpectroCloudRole",          // IAM role name
+		"Base",                      // IAM check type
+		"y",                         // enable service quota validation
+		"EC2",                       // rule name
+		"EC2-VPC Elastic IPs",       // service quota type
+		"us-west-2",                 // service quota region #1
+		"5",                         // service quota buffer #1
+		"n",                         // add another service quota rule
+		"y",                         // enable subnet tag validation
+		"subnet",                    // tag resource type
+		"elb tag rule",              // rule name
+		"us-west-2",                 // subnet tag region #1
+		"foo",                       // subnet tag key #1
+		"bar",                       // subnet tag value #1
+		"baz",                       // subnet arn #1
+		"n",                         // add another subnet arn
+		"n",                         // add another subnet tag rule
+		"n",                         // add another tag rule
+	}...)
+	if string_utils.IsDevVersion(ctx.Get("version")) {
+		tuiVals = slices.Insert(tuiVals, 2,
+			cfg.ValidatorChartVersions[cfg.ValidatorPluginAws], // validator-plugin-aws helm chart version
+		)
+	}
+	return tuiVals
+}
+
+func (t *ValidatorTest) azurePluginValues(ctx *test.TestContext, tuiVals []string) []string {
+	tuiVals = append(tuiVals, []string{
+		"y",                                    // enable plugin
+		cfg.ValidatorHelmRepository,            // helm chart repo
+		"n",                                    // Re-use validator chart security configuration
+		"y",                                    // insecure skip verify
+		"n",                                    // use basic auth
+		"n",                                    // implicit plugin auth
+		"azure-creds",                          // k8s secret name
+		"d551b7b1-78ae-43df-9d61-4935c843a454", // tenant id
+		"d551b7b1-78ae-43df-9d61-4935c843a454", // client id
+		"test_client_secret",                   // client secret
+		"Cluster Deployment",                   // rule type (select)
+		"Static",                               // placement type (select)
+		"Single cluster",                       // static deployment style (select)
+		"rule-1",                               // rule name
+		"d551b7b1-78ae-43df-9d61-4935c843a454", // service principal
+		"d551b7b1-78ae-43df-9d61-4935c843a454", // subscription
+		"rg",                                   // resource group
+		"vn",                                   // virtual network
+		"s",                                    // subnet
+		"acg",                                  // azure compute gallery
+		"y",                                    // add RBAC rule
+		"Cluster Deployment",                   // rule type (select)
+		"Static",                               // placement type (select)
+		"Multiple clusters in a single resource group", // static deployment style (select)
+		"rule-2",                               // rule name
+		"d551b7b1-78ae-43df-9d61-4935c843a454", // service principal
+		"d551b7b1-78ae-43df-9d61-4935c843a454", // subscription
+		"rg",                                   // resource group
+		"y",                                    // add RBAC rule
+		"Cluster Deployment",                   // rule type (select)
+		"Static",                               // placement type (select)
+		"Multiple clusters in a single subscription", // static deployment style (select)
+		"rule-3",                               // rule name
+		"d551b7b1-78ae-43df-9d61-4935c843a454", // service principal
+		"d551b7b1-78ae-43df-9d61-4935c843a454", // subscription
+		"y",                                    // add RBAC rule
+		"Cluster Deployment",                   // rule type (select)
+		"Dynamic",                              // placement type (select)
+		"rule-4",                               // rule name
+		"d551b7b1-78ae-43df-9d61-4935c843a454", // service principal
+		"d551b7b1-78ae-43df-9d61-4935c843a454", // subscription
+		"y",                                    // add RBAC rule
+		"Custom",                               // rule type (select)
+		"rule-5",                               // rule name
+		"d551b7b1-78ae-43df-9d61-4935c843a454", // security principal
+		"s",                                    // scope
+		"a",                                    // Action
+		"n",                                    // add Action
+		"da",                                   // DataAction
+		"n",                                    // add DataAction
+		"n",                                    // add permission set
+		"n",                                    // add RBAC rule
+	}...)
+	if string_utils.IsDevVersion(ctx.Get("version")) {
+		tuiVals = slices.Insert(tuiVals, 2,
+			cfg.ValidatorChartVersions[cfg.ValidatorPluginAzure], // validator-plugin-azure helm chart version
+		)
+	}
+	return tuiVals
+}
+
+func (t *ValidatorTest) networkPluginValues(ctx *test.TestContext, tuiVals []string) []string {
+	tuiVals = append(tuiVals, []string{
+		"y",                         // enable Network plugin
+		cfg.ValidatorHelmRepository, // validator-plugin-network helm chart repo
+		"y",                         // Re-use validator chart security configuration
+		"y",                         // enable DNS validation
+		"resolve foo",               // DNS rule name
+		"foo",                       // DNS host
+		"",                          // DNS nameserver
+		"n",                         // add another DNS rule
+		"y",                         // enable ICMP validation
+		"ping foo",                  // ICMP rule name
+		"foo",                       // ICMP host
+		"n",                         // add another ICMP rule
+		"y",                         // enable IP range validation
+		"check ips",                 // IP range rule name
+		"10.10.10.10",               // first IPv4 in range
+		"10",                        // length of IPv4 range
+		"n",                         // add another IP range rule
+		"y",                         // enable MTU validation
+		"check mtu",                 // MTU rule name
+		"foo",                       // MTU host
+		"1500",                      // minimum MTU
+		"n",                         // add another MTU rule
+		"y",                         // enable TCP connection validation
+		"check tcp",                 // TCP connection rule name
+		"foo",                       // TCP connection host
+		"80",                        // TCP connection port
+		"n",                         // add another port
+		"n",                         // add another TCP connection rule
+	}...)
+	if string_utils.IsDevVersion(ctx.Get("version")) {
+		tuiVals = slices.Insert(tuiVals, 2,
+			cfg.ValidatorChartVersions[cfg.ValidatorPluginNetwork], // validator-plugin-network helm chart version
+		)
+	}
+	return tuiVals
+}
+
+func (t *ValidatorTest) ociPluginValues(ctx *test.TestContext, tuiVals []string) []string {
+	tuiVals = append(tuiVals, []string{
+		"y",                         // enable OCI plugin
+		cfg.ValidatorHelmRepository, // validator-plugin-oci helm chart repo
+		"y",                         // Re-use validator chart security configuration
+		"y",                         // add registry credentials
+		"oci-creds",                 // secret name
+		"user1",                     // username
+		"pa$$w0rd",                  // password
+		"n",                         // add another registry credential
+		"y",                         // add signature verification secret
+		"cosign-pubkeys",            // secret name
+		t.filePath("cosign.pub"),    // public key file
+		"n",                         // add another public key to this secret
+		"n",                         // add another signature verification secret
+		"public ecr registry",       // rule name
+		"public.ecr.aws",            // registry host
+		"N/A",                       // registry auth secret name
+		"u5n5j0b4/oci-test-public",  // artifact ref
+		"n",                         // enable full layer validation
+		"n",                         // add another artifact
+		"N/A",                       // signature verification secret name
+		"",                          // ca certificate
+		"n",                         // add another registry rule
+	}...)
+	if string_utils.IsDevVersion(ctx.Get("version")) {
+		tuiVals = slices.Insert(tuiVals, 2,
+			cfg.ValidatorChartVersions[cfg.ValidatorPluginOci], // validator-plugin-oci helm chart version
+		)
+	}
+	return tuiVals
+}
+
+func (t *ValidatorTest) vspherePluginValues(ctx *test.TestContext, tuiVals []string) []string {
+	tuiVals = append(tuiVals, []string{
+		"y",                                // enable vsphere plugin
+		cfg.ValidatorHelmRepository,        // validator-plugin-vsphere helm chart repo
+		"y",                                // Re-use validator chart security configuration
+		"vsphere-creds",                    // vSphere secret name
+		"fake.vsphere.com",                 // vSphere domain
+		"bob@vsphere.com",                  // vSphere username
+		"password",                         // vSphere password
+		"y",                                // insecure skip verify
+		"DC0",                              // datacenter
+		"y",                                // Enable NTP check
+		"ntpd",                             // NTP rule name
+		"y",                                // are hosts cluster scoped
+		"C0",                               // cluster name
+		"DC0_C0_H0",                        // host1
+		"y",                                // add more hosts
+		"DC0_C0_H1",                        // host2
+		"n",                                // add more hosts
+		"n",                                // add more validation rules
+		"y",                                // Check role privileges
+		"role rule 1",                      // Role privilege rule name
+		"user1@vsphere.local",              // user to check role privileges against
+		cfg.SpectroRootLevelPrivilegesV7_0, // vSphere permission version
+		"n",                                // add more role privilege checks
+		"y",                                // check entity privileges
+		"entity rule 1",                    // entity privilege rule name
+		cfg.SpectroEntityPrivileges,        // entity level permissions
+		"Read folder: spectro-templates",   // spectro entity permission
+		"user2@vsphere.local",              // user to check entity privileges against
+		"n",                                // add more entity permission checks
+		"y",                                // check compute resource requirements
+		"resource requirement rule 1",      // resource requirement rule name
+		"Cluster",                          // select cluster for resource check
+		"C0",                               // cluster name for resource check
+		"master-pool",                      // node pool name
+		"1",                                // number of nodes
+		"2GHz",                             // per node cpu
+		"4Gi",                              // per node memory
+		"10Gi",                             // per node storage
+		"y",                                // add another node pool
+		"worker-pool",                      // node pool name
+		"3",                                // number of nodes
+		"3GHz",                             // per node cpu
+		"8Gi",                              // per node memory
+		"20Gi",                             // per node storage
+		"n",                                // add more node pools
+		"n",                                // add more resource requirement checks
+		"y",                                // check tags on entities
+		"tag rule 1",                       // tag rule name
+		cfg.SpectroCloudTags,               // zone & region tags
+		"Cluster: k8s-zone (ensure that the selected cluster has a 'k8s-zone' tag)", // zone tag
+		"C0", // cluster name
+		"n",  // add another tag rule
+	}...)
+	if string_utils.IsDevVersion(ctx.Get("version")) {
+		tuiVals = slices.Insert(tuiVals, 2,
+			cfg.ValidatorChartVersions[cfg.ValidatorPluginVsphere], // validator-plugin-vsphere helm chart version
+		)
+	}
+	return tuiVals
 }
 
 func (t *ValidatorTest) testDeploySilent() (tr *test.TestResult) {

--- a/tests/integration/_validator/testcases/test_validator.go
+++ b/tests/integration/_validator/testcases/test_validator.go
@@ -135,23 +135,24 @@ func (t *ValidatorTest) testDeployInteractive(ctx *test.TestContext) (tr *test.T
 }
 
 func (t *ValidatorTest) baseHelmValues(ctx *test.TestContext, tuiVals []string) []string {
-	tuiVals = append(tuiVals, []string{
+	baseVals := []string{
 		cfg.ValidatorHelmRepository, // validator helm chart repo
 		"y",                         // insecure skip verify
 		"y",                         // use basic auth
 		"bob",                       // release secret username
 		"dog",                       // release secret password
-	}...)
+	}
 	if string_utils.IsDevVersion(ctx.Get("version")) {
-		tuiVals = slices.Insert(tuiVals, 1,
+		baseVals = slices.Insert(baseVals, 1,
 			cfg.ValidatorChartVersions[cfg.Validator], // validator helm chart version
 		)
 	}
+	tuiVals = append(tuiVals, baseVals...)
 	return tuiVals
 }
 
 func (t *ValidatorTest) awsPluginValues(ctx *test.TestContext, tuiVals []string) []string {
-	tuiVals = append(tuiVals, []string{
+	awsVals := []string{
 		"y",                         // enable AWS plugin
 		cfg.ValidatorHelmRepository, // validator-plugin-aws helm chart repo
 		"y",                         // Re-use validator chart security configuration
@@ -184,17 +185,18 @@ func (t *ValidatorTest) awsPluginValues(ctx *test.TestContext, tuiVals []string)
 		"n",                         // add another subnet arn
 		"n",                         // add another subnet tag rule
 		"n",                         // add another tag rule
-	}...)
+	}
 	if string_utils.IsDevVersion(ctx.Get("version")) {
-		tuiVals = slices.Insert(tuiVals, 2,
+		awsVals = slices.Insert(awsVals, 2,
 			cfg.ValidatorChartVersions[cfg.ValidatorPluginAws], // validator-plugin-aws helm chart version
 		)
 	}
+	tuiVals = append(tuiVals, awsVals...)
 	return tuiVals
 }
 
 func (t *ValidatorTest) azurePluginValues(ctx *test.TestContext, tuiVals []string) []string {
-	tuiVals = append(tuiVals, []string{
+	azureVals := []string{
 		"y",                                    // enable plugin
 		cfg.ValidatorHelmRepository,            // helm chart repo
 		"n",                                    // Re-use validator chart security configuration
@@ -247,17 +249,18 @@ func (t *ValidatorTest) azurePluginValues(ctx *test.TestContext, tuiVals []strin
 		"n",                                    // add DataAction
 		"n",                                    // add permission set
 		"n",                                    // add RBAC rule
-	}...)
+	}
 	if string_utils.IsDevVersion(ctx.Get("version")) {
-		tuiVals = slices.Insert(tuiVals, 2,
+		azureVals = slices.Insert(azureVals, 2,
 			cfg.ValidatorChartVersions[cfg.ValidatorPluginAzure], // validator-plugin-azure helm chart version
 		)
 	}
+	tuiVals = append(tuiVals, azureVals...)
 	return tuiVals
 }
 
 func (t *ValidatorTest) networkPluginValues(ctx *test.TestContext, tuiVals []string) []string {
-	tuiVals = append(tuiVals, []string{
+	networkVals := []string{
 		"y",                         // enable Network plugin
 		cfg.ValidatorHelmRepository, // validator-plugin-network helm chart repo
 		"y",                         // Re-use validator chart security configuration
@@ -286,17 +289,18 @@ func (t *ValidatorTest) networkPluginValues(ctx *test.TestContext, tuiVals []str
 		"80",                        // TCP connection port
 		"n",                         // add another port
 		"n",                         // add another TCP connection rule
-	}...)
+	}
 	if string_utils.IsDevVersion(ctx.Get("version")) {
-		tuiVals = slices.Insert(tuiVals, 2,
+		networkVals = slices.Insert(networkVals, 2,
 			cfg.ValidatorChartVersions[cfg.ValidatorPluginNetwork], // validator-plugin-network helm chart version
 		)
 	}
+	tuiVals = append(tuiVals, networkVals...)
 	return tuiVals
 }
 
 func (t *ValidatorTest) ociPluginValues(ctx *test.TestContext, tuiVals []string) []string {
-	tuiVals = append(tuiVals, []string{
+	ociVals := []string{
 		"y",                         // enable OCI plugin
 		cfg.ValidatorHelmRepository, // validator-plugin-oci helm chart repo
 		"y",                         // Re-use validator chart security configuration
@@ -319,17 +323,18 @@ func (t *ValidatorTest) ociPluginValues(ctx *test.TestContext, tuiVals []string)
 		"N/A",                       // signature verification secret name
 		"",                          // ca certificate
 		"n",                         // add another registry rule
-	}...)
+	}
 	if string_utils.IsDevVersion(ctx.Get("version")) {
-		tuiVals = slices.Insert(tuiVals, 2,
+		ociVals = slices.Insert(ociVals, 2,
 			cfg.ValidatorChartVersions[cfg.ValidatorPluginOci], // validator-plugin-oci helm chart version
 		)
 	}
+	tuiVals = append(tuiVals, ociVals...)
 	return tuiVals
 }
 
 func (t *ValidatorTest) vspherePluginValues(ctx *test.TestContext, tuiVals []string) []string {
-	tuiVals = append(tuiVals, []string{
+	vsphereVals := []string{
 		"y",                                // enable vsphere plugin
 		cfg.ValidatorHelmRepository,        // validator-plugin-vsphere helm chart repo
 		"y",                                // Re-use validator chart security configuration
@@ -382,12 +387,13 @@ func (t *ValidatorTest) vspherePluginValues(ctx *test.TestContext, tuiVals []str
 		"Cluster: k8s-zone (ensure that the selected cluster has a 'k8s-zone' tag)", // zone tag
 		"C0", // cluster name
 		"n",  // add another tag rule
-	}...)
+	}
 	if string_utils.IsDevVersion(ctx.Get("version")) {
-		tuiVals = slices.Insert(tuiVals, 2,
+		vsphereVals = slices.Insert(vsphereVals, 2,
 			cfg.ValidatorChartVersions[cfg.ValidatorPluginVsphere], // validator-plugin-vsphere helm chart version
 		)
 	}
+	tuiVals = append(tuiVals, vsphereVals...)
 	return tuiVals
 }
 

--- a/tests/integration/common/single_func_test_case.go
+++ b/tests/integration/common/single_func_test_case.go
@@ -10,10 +10,10 @@ type SingleFuncTestCase struct {
 	log *log.Entry
 	*test.BaseTest
 
-	testFunc func() error
+	testFunc func(*test.TestContext) error
 }
 
-func NewSingleFuncTest(name string, testFunc func() error) *SingleFuncTestCase {
+func NewSingleFuncTest(name string, testFunc func(*test.TestContext) error) *SingleFuncTestCase {
 	return &SingleFuncTestCase{
 		log:      log.WithField("func", name),
 		testFunc: testFunc,
@@ -23,7 +23,7 @@ func NewSingleFuncTest(name string, testFunc func() error) *SingleFuncTestCase {
 
 func (r *SingleFuncTestCase) Execute(ctx *test.TestContext) (tr *test.TestResult) {
 	r.log.Printf("Executing %s", r.GetName())
-	if err := r.testFunc(); err != nil {
+	if err := r.testFunc(ctx); err != nil {
 		r.log.Errorf("Failed to run test: %v", err)
 		return test.Failure(err.Error())
 	}

--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -14,16 +14,16 @@ import (
 )
 
 func TestIntegrationSuite(t *testing.T) {
-	if err := setup(); err != nil {
+	testCtx := test.NewTestContext()
+	if err := setup(testCtx); err != nil {
 		t.Errorf("failed to setup integration test suite: %v", err)
 	}
-	runSuite(t)
+	runSuite(testCtx, t)
 }
 
-func runSuite(t *testing.T) {
+func runSuite(testCtx *test.TestContext, t *testing.T) {
 	fmt.Println("Validator CLI Integration Test Suite")
 
-	testCtx := test.NewTestContext()
 	err := test.Flow(testCtx).
 		Test(common.NewSingleFuncTest("validator-test", validator.Execute)).
 		Summarize().TearDown().Audit()
@@ -33,13 +33,14 @@ func runSuite(t *testing.T) {
 	}
 }
 
-func setup() error {
+func setup(testCtx *test.TestContext) error {
 	// Set CLI version
 	version := os.Getenv("CLI_VERSION")
 	if version == "" && cmd.Version == "" {
 		log.Fatal("CLI_VERSION environment variable or ldflags must be set")
 	}
 	cmd.Version = version
+	testCtx.Put("version", version)
 
 	// Wipe out the default config & workspace location
 	defaultWorkspace, err := cfg.DefaultWorkspaceLoc()
@@ -50,7 +51,7 @@ func setup() error {
 		log.Fatal(err.Error())
 	}
 
-	// Initialze config, workspace, binaries, logger
+	// Initialize config, workspace, logger
 	cmd.InitConfig()
 	return nil
 }


### PR DESCRIPTION
## Description
Ensures that the integration test suite passes when executed against a non-dev (AKA release) CLI version.

- properly propagates global test suite context into each test suite, rather than initializing new test contexts in various places
- dynamically constructs mock TUI values based on CLI version
