### PR TITLE
feat: add helpers to easily configure validator plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/vmware/govmomi v0.38.0
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.2
 	k8s.io/apimachinery v0.30.2
 	k8s.io/client-go v0.30.2
@@ -56,6 +55,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/gookit/color v1.5.4 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
@@ -101,6 +101,7 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.30.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240521193020-835d969ad83a // indirect

--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -80,7 +80,7 @@ func DeployValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig, reconfigure bool)
 
 	// save / print validator config file
 	if saveConfig {
-		if err := components.SaveValidatorConfig(vc, tc); err != nil {
+		if err := components.SaveValidatorConfig(vc, tc.ConfigFile); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/components/network.go
+++ b/pkg/components/network.go
@@ -1,1 +1,39 @@
 package components
+
+import (
+	"fmt"
+
+	network_api "github.com/validator-labs/validator-plugin-network/api/v1alpha1"
+	vapi "github.com/validator-labs/validator/api/v1alpha1"
+
+	cfg "github.com/validator-labs/validatorctl/pkg/config"
+)
+
+type NetworkConfig struct {
+	VcenterServer string
+	IPRangeRules  []network_api.IPRangeRule
+	TCPConnRules  []network_api.TCPConnRule
+}
+
+func ConfigureNetworkPlugin(vc *ValidatorConfig, config NetworkConfig) error {
+	vc.NetworkPlugin = &NetworkPluginConfig{
+		Enabled: true,
+		Release: &vapi.HelmRelease{
+			Chart: vapi.HelmChart{
+				Name:                  cfg.ValidatorPluginNetwork,
+				Repository:            fmt.Sprintf("%s/%s", cfg.ValidatorHelmRepository, cfg.ValidatorPluginNetwork),
+				Version:               cfg.ValidatorChartVersions[cfg.ValidatorPluginNetwork],
+				InsecureSkipTlsVerify: true,
+			},
+		},
+		ReleaseSecret: &Secret{
+			Name: fmt.Sprintf("validator-helm-release-%s", cfg.ValidatorPluginNetwork),
+		},
+		Validator: &network_api.NetworkValidatorSpec{
+			IPRangeRules: config.IPRangeRules,
+			TCPConnRules: config.TCPConnRules,
+		},
+	}
+
+	return nil
+}

--- a/pkg/components/network.go
+++ b/pkg/components/network.go
@@ -15,7 +15,7 @@ type NetworkConfig struct {
 	TCPConnRules  []network_api.TCPConnRule
 }
 
-func ConfigureNetworkPlugin(vc *ValidatorConfig, config NetworkConfig) error {
+func ConfigureNetworkPlugin(vc *ValidatorConfig, config NetworkConfig) {
 	vc.NetworkPlugin = &NetworkPluginConfig{
 		Enabled: true,
 		Release: &vapi.HelmRelease{
@@ -34,6 +34,4 @@ func ConfigureNetworkPlugin(vc *ValidatorConfig, config NetworkConfig) error {
 			TCPConnRules: config.TCPConnRules,
 		},
 	}
-
-	return nil
 }

--- a/pkg/components/network.go
+++ b/pkg/components/network.go
@@ -1,0 +1,1 @@
+package components

--- a/pkg/components/oci.go
+++ b/pkg/components/oci.go
@@ -1,1 +1,59 @@
 package components
+
+import (
+	"fmt"
+
+	oci_api "github.com/validator-labs/validator-plugin-oci/api/v1alpha1"
+	vapi "github.com/validator-labs/validator/api/v1alpha1"
+
+	cfg "github.com/validator-labs/validatorctl/pkg/config"
+)
+
+type OciConfig struct {
+	// HostRefs is a map of hostnames to a list of artifact references
+	HostRefs map[string][]string
+}
+
+func ConfigureOciPlugin(vc *ValidatorConfig, config OciConfig) error {
+	vc.OCIPlugin = &OCIPluginConfig{
+		Enabled: true,
+		Release: &vapi.HelmRelease{
+			Chart: vapi.HelmChart{
+				Name:                  cfg.ValidatorPluginOci,
+				Repository:            fmt.Sprintf("%s/%s", cfg.ValidatorHelmRepository, cfg.ValidatorPluginOci),
+				Version:               cfg.ValidatorChartVersions[cfg.ValidatorPluginOci],
+				InsecureSkipTlsVerify: true,
+			},
+		},
+		ReleaseSecret: &Secret{
+			Name: fmt.Sprintf("validator-helm-release-%s", cfg.ValidatorPluginOci),
+		},
+		Validator: &oci_api.OciValidatorSpec{
+			OciRegistryRules: generateOciRegistryRules(config.HostRefs),
+		},
+	}
+
+	return nil
+}
+
+func generateOciRegistryRules(hostRefs map[string][]string) []oci_api.OciRegistryRule {
+	var rules []oci_api.OciRegistryRule
+	for host, refs := range hostRefs {
+		rule := oci_api.OciRegistryRule{
+			RuleName: fmt.Sprintf("artifacts on %s", host),
+			Host:     host,
+		}
+
+		artifacts := []oci_api.Artifact{}
+		for _, ref := range refs {
+			artifacts = append(artifacts, oci_api.Artifact{
+				Ref:             ref,
+				LayerValidation: true,
+			})
+		}
+		rule.Artifacts = artifacts
+
+		rules = append(rules, rule)
+	}
+	return rules
+}

--- a/pkg/components/oci.go
+++ b/pkg/components/oci.go
@@ -14,7 +14,7 @@ type OciConfig struct {
 	HostRefs map[string][]string
 }
 
-func ConfigureOciPlugin(vc *ValidatorConfig, config OciConfig) error {
+func ConfigureOciPlugin(vc *ValidatorConfig, config OciConfig) {
 	vc.OCIPlugin = &OCIPluginConfig{
 		Enabled: true,
 		Release: &vapi.HelmRelease{
@@ -32,8 +32,6 @@ func ConfigureOciPlugin(vc *ValidatorConfig, config OciConfig) error {
 			OciRegistryRules: generateOciRegistryRules(config.HostRefs),
 		},
 	}
-
-	return nil
 }
 
 func generateOciRegistryRules(hostRefs map[string][]string) []oci_api.OciRegistryRule {

--- a/pkg/components/oci.go
+++ b/pkg/components/oci.go
@@ -1,0 +1,1 @@
+package components

--- a/pkg/components/validator.go
+++ b/pkg/components/validator.go
@@ -546,7 +546,7 @@ func SaveValidatorConfig(c *ValidatorConfig, tc *cfg.TaskConfig) error {
 	return nil
 }
 
-func ConfigureBaseValidator(vc *ValidatorConfig, kubeconfig string) error {
+func ConfigureBaseValidator(vc *ValidatorConfig, kubeconfig string) {
 	vc.Release = &validator.HelmRelease{
 		Chart: validator.HelmChart{
 			Name:                  cfg.Validator,
@@ -568,6 +568,4 @@ func ConfigureBaseValidator(vc *ValidatorConfig, kubeconfig string) error {
 		},
 	}
 	vc.UseFixedVersions = true
-
-	return nil
 }

--- a/pkg/components/validator.go
+++ b/pkg/components/validator.go
@@ -1,21 +1,11 @@
 package components
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
-	"time"
 
 	"emperror.dev/errors"
 	"gopkg.in/yaml.v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/tools/cache"
-	toolsWatch "k8s.io/client-go/tools/watch"
 
 	aws "github.com/validator-labs/validator-plugin-aws/api/v1alpha1"
 	azure "github.com/validator-labs/validator-plugin-azure/api/v1alpha1"
@@ -29,8 +19,6 @@ import (
 	log "github.com/validator-labs/validatorctl/pkg/logging"
 	env "github.com/validator-labs/validatorctl/pkg/services"
 	"github.com/validator-labs/validatorctl/pkg/utils/crypto"
-	"github.com/validator-labs/validatorctl/pkg/utils/embed"
-	"github.com/validator-labs/validatorctl/pkg/utils/kube"
 )
 
 type ValidatorConfig struct {
@@ -515,8 +503,8 @@ func (s *Secret) decrypt() error {
 }
 
 // NewValidatorFromConfig loads a validator configuration file from disk and decrypts it
-func NewValidatorFromConfig(taskConfig *cfg.TaskConfig) (*ValidatorConfig, error) {
-	c, err := LoadValidatorConfig(taskConfig)
+func NewValidatorFromConfig(tc *cfg.TaskConfig) (*ValidatorConfig, error) {
+	c, err := LoadValidatorConfig(tc)
 	if err != nil {
 		return nil, err
 	}
@@ -527,8 +515,8 @@ func NewValidatorFromConfig(taskConfig *cfg.TaskConfig) (*ValidatorConfig, error
 }
 
 // LoadValidatorConfig loads a validator configuration file from disk
-func LoadValidatorConfig(taskConfig *cfg.TaskConfig) (*ValidatorConfig, error) {
-	bytes, err := os.ReadFile(taskConfig.ConfigFile)
+func LoadValidatorConfig(tc *cfg.TaskConfig) (*ValidatorConfig, error) {
+	bytes, err := os.ReadFile(tc.ConfigFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read validator config file")
 	}
@@ -540,7 +528,7 @@ func LoadValidatorConfig(taskConfig *cfg.TaskConfig) (*ValidatorConfig, error) {
 }
 
 // SaveValidatorConfig saves a validator configuration file to disk
-func SaveValidatorConfig(c *ValidatorConfig, fileName string) error {
+func SaveValidatorConfig(c *ValidatorConfig, tc *cfg.TaskConfig) error {
 	if err := c.encrypt(); err != nil {
 		return err
 	}
@@ -551,10 +539,10 @@ func SaveValidatorConfig(c *ValidatorConfig, fileName string) error {
 	if err := c.decrypt(); err != nil {
 		return err
 	}
-	if err = os.WriteFile(fileName, b, 0600); err != nil {
+	if err = os.WriteFile(tc.ConfigFile, b, 0600); err != nil {
 		return errors.Wrap(err, "failed to create validator config file")
 	}
-	log.InfoCLI("validator configuration file saved: %s", fileName)
+	log.InfoCLI("validator configuration file saved: %s", tc.ConfigFile)
 	return nil
 }
 
@@ -582,162 +570,4 @@ func ConfigureBaseValidator(vc *ValidatorConfig, kubeconfig string) error {
 	vc.UseFixedVersions = true
 
 	return nil
-}
-
-func WatchValidationResults(vc *ValidatorConfig) (bool, error) {
-	log.InfoCLI("\nWatching validation results, waiting for all to succeed")
-	kClient, err := getValidationResultsCRDClient(vc)
-	if err != nil {
-		return false, errors.Wrap(err, "failed to get validation result client")
-	}
-
-	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
-		return kClient.Watch(context.Background(), metav1.ListOptions{})
-	}
-
-	watcher, err := toolsWatch.NewRetryWatcher("1", &cache.ListWatch{WatchFunc: watchFunc})
-	if err != nil {
-		return false, errors.Wrap(err, "failed to create retry watcher for validation results")
-	}
-
-	var hasValidationSucceeded bool
-	validationStates := make(map[string]validator.ValidationState)
-
-	if os.Getenv("IS_TEST") == "true" {
-		return true, nil
-	}
-
-	for event := range watcher.ResultChan() {
-		vrObj := event.Object.(*unstructured.Unstructured)
-
-		vr := &validator.ValidationResult{}
-		bytes, err := vrObj.MarshalJSON()
-		if err != nil {
-			return false, err
-		}
-		if err := json.Unmarshal(bytes, vr); err != nil {
-			return false, err
-		}
-
-		prevValidationState := validationStates[vr.Name]
-		validationStates[vr.Name] = vr.Status.State
-		if event.Type != watch.Modified {
-			continue
-		}
-
-		hasValidationSucceeded = true
-		if prevValidationState != vr.Status.State {
-			log.InfoCLI("\nValidation result for %s updated:", vr.Name)
-			err = printValidationResults([]unstructured.Unstructured{*vrObj})
-			if err != nil {
-				return false, err
-			}
-
-			finished := true
-			vrWaiting := make([]string, 0)
-			for vName, state := range validationStates {
-				if state == validator.ValidationFailed {
-					hasValidationSucceeded = false
-				}
-				if state != validator.ValidationSucceeded && state != validator.ValidationFailed {
-					vrWaiting = append(vrWaiting, vName)
-					finished = false
-					break
-				}
-			}
-			if finished {
-				break
-			}
-
-			log.InfoCLI("\nWatching for updates to validation results for %s...", vrWaiting)
-		}
-	}
-	log.InfoCLI("\nAll validations have completed.")
-	return hasValidationSucceeded, nil
-}
-
-func getValidationResultsCRDClient(vc *ValidatorConfig) (dynamic.NamespaceableResourceInterface, error) {
-	if err := os.Setenv("KUBECONFIG", vc.Kubeconfig); err != nil {
-		return nil, err
-	}
-	log.InfoCLI("Using kubeconfig from validator configuration file: %s", vc.Kubeconfig)
-
-	gv := kube.GetGroupVersion("validation.spectrocloud.labs", "v1alpha1")
-	kClient, err := kube.GetCRDClient(gv, "validationresults")
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get validation result client")
-	}
-
-	return kClient, nil
-}
-
-func printValidationResults(validationResults []unstructured.Unstructured) error {
-	for _, vrObj := range validationResults {
-		vrStr, err := buildValidationResultString(vrObj)
-		if err != nil {
-			return err
-		}
-		log.InfoCLI(vrStr)
-	}
-
-	return nil
-}
-
-func buildValidationResultString(vrObj unstructured.Unstructured) (string, error) {
-	vr := &validator.ValidationResult{}
-	bytes, err := vrObj.MarshalJSON()
-	if err != nil {
-		return "", err
-	}
-	if err := json.Unmarshal(bytes, vr); err != nil {
-		return "", err
-	}
-
-	sb := &strings.Builder{}
-	sb.WriteString("\n=================\nValidation Result\n=================\n")
-	keys := []string{"Plugin", "Name", "Namespace", "State"}
-	vals := []string{vr.Spec.Plugin, vr.Name, vr.Namespace, string(vr.Status.State)}
-
-	for _, c := range vr.Status.Conditions {
-		if c.Type == validator.SinkEmission {
-			keys = append(keys, "Sink State")
-			vals = append(vals, string(c.Reason))
-			break
-		}
-	}
-
-	args := map[string]interface{}{
-		"Keys":   keys,
-		"Values": vals,
-	}
-
-	if err := embed.PrintTableTemplate(sb, args, cfg.Validator, "validation-result.tmpl"); err != nil {
-		return "", err
-	}
-
-	sb.WriteString("\n------------\nRule Results\n------------\n")
-	for _, c := range vr.Status.ValidationConditions {
-		args := map[string]interface{}{
-			"Keys":   []string{"Validation Rule", "Validation Type", "Status", "Last Validated", "Message"},
-			"Values": []string{c.ValidationRule, c.ValidationType, string(c.Status), c.LastValidationTime.Format(time.RFC3339), strings.TrimSpace(c.Message)},
-		}
-
-		if err := embed.PrintTableTemplate(sb, args, cfg.Validator, "validation-result.tmpl"); err != nil {
-			return "", err
-		}
-
-		for i, d := range c.Details {
-			if i == 0 {
-				sb.WriteString("\n-------\nDetails\n-------\n")
-			}
-			sb.WriteString(fmt.Sprintf("- %s\n", d))
-		}
-		for i, f := range c.Failures {
-			if i == 0 {
-				sb.WriteString("\n--------\nFailures\n--------\n")
-			}
-			sb.WriteString(fmt.Sprintf("- %s\n", f))
-		}
-	}
-	return sb.String(), nil
 }

--- a/pkg/components/validator.go
+++ b/pkg/components/validator.go
@@ -528,7 +528,7 @@ func LoadValidatorConfig(taskConfig *cfg.TaskConfig) (*ValidatorConfig, error) {
 }
 
 // SaveValidatorConfig saves a validator configuration file to disk
-func SaveValidatorConfig(c *ValidatorConfig, taskConfig *cfg.TaskConfig) error {
+func SaveValidatorConfig(c *ValidatorConfig, fileName string) error {
 	if err := c.encrypt(); err != nil {
 		return err
 	}
@@ -539,10 +539,10 @@ func SaveValidatorConfig(c *ValidatorConfig, taskConfig *cfg.TaskConfig) error {
 	if err := c.decrypt(); err != nil {
 		return err
 	}
-	if err = os.WriteFile(taskConfig.ConfigFile, b, 0600); err != nil {
+	if err = os.WriteFile(fileName, b, 0600); err != nil {
 		return errors.Wrap(err, "failed to create validator config file")
 	}
-	log.InfoCLI("validator configuration file saved: %s", taskConfig.ConfigFile)
+	log.InfoCLI("validator configuration file saved: %s", fileName)
 	return nil
 }
 

--- a/pkg/components/vsphere.go
+++ b/pkg/components/vsphere.go
@@ -22,7 +22,7 @@ type VsphereConfig struct {
 	Privileges                   []string
 }
 
-func ConfigureVspherePlugin(vc *ValidatorConfig, config VsphereConfig) error {
+func ConfigureVspherePlugin(vc *ValidatorConfig, config VsphereConfig) {
 	vc.VspherePlugin = &VspherePluginConfig{
 		Enabled: true,
 		Release: &vapi.HelmRelease{
@@ -74,5 +74,4 @@ func ConfigureVspherePlugin(vc *ValidatorConfig, config VsphereConfig) error {
 			TagValidationRules: config.TagValidationRules,
 		},
 	}
-	return nil
 }

--- a/pkg/components/vsphere.go
+++ b/pkg/components/vsphere.go
@@ -1,0 +1,78 @@
+package components
+
+import (
+	"fmt"
+
+	vsphere_api "github.com/validator-labs/validator-plugin-vsphere/api/v1alpha1"
+	"github.com/validator-labs/validator-plugin-vsphere/pkg/vsphere"
+	vapi "github.com/validator-labs/validator/api/v1alpha1"
+
+	cfg "github.com/validator-labs/validatorctl/pkg/config"
+)
+
+type VsphereConfig struct {
+	Username                     string
+	Password                     string
+	VcenterServer                string
+	Datacenter                   string
+	ClusterName                  string
+	ImageTemplateFolder          string
+	NodePoolResourceRequirements []vsphere_api.NodepoolResourceRequirement
+	TagValidationRules           []vsphere_api.TagValidationRule
+	Privileges                   []string
+}
+
+func ConfigureVspherePlugin(vc *ValidatorConfig, config VsphereConfig) error {
+	vc.VspherePlugin = &VspherePluginConfig{
+		Enabled: true,
+		Release: &vapi.HelmRelease{
+			Chart: vapi.HelmChart{
+				Name:                  cfg.ValidatorPluginVsphere,
+				Repository:            fmt.Sprintf("%s/%s", cfg.ValidatorHelmRepository, cfg.ValidatorPluginVsphere),
+				Version:               cfg.ValidatorChartVersions[cfg.ValidatorPluginVsphere],
+				InsecureSkipTlsVerify: true,
+			},
+		},
+		ReleaseSecret: &Secret{
+			Name: fmt.Sprintf("validator-helm-release-%s", cfg.ValidatorPluginVsphere),
+		},
+		Account: &vsphere.VsphereCloudAccount{
+			Insecure:      true,
+			Username:      config.Username,
+			Password:      config.Password,
+			VcenterServer: config.VcenterServer,
+		},
+		Validator: &vsphere_api.VsphereValidatorSpec{
+			Auth: vsphere_api.VsphereAuth{
+				SecretName: "vsphere-creds",
+			},
+			Datacenter: config.Datacenter,
+			ComputeResourceRules: []vsphere_api.ComputeResourceRule{
+				{
+					Name:                         "Cluster Compute Resource Availability",
+					ClusterName:                  config.ClusterName,
+					Scope:                        "cluster",
+					EntityName:                   config.ClusterName,
+					NodepoolResourceRequirements: config.NodePoolResourceRequirements,
+				},
+			},
+			EntityPrivilegeValidationRules: []vsphere_api.EntityPrivilegeValidationRule{
+				{
+					Name:       "Create folder: image template folder",
+					Username:   config.Username,
+					EntityType: "folder",
+					EntityName: config.ImageTemplateFolder,
+					Privileges: []string{"Folder.Create"},
+				},
+			},
+			RolePrivilegeValidationRules: []vsphere_api.GenericRolePrivilegeValidationRule{
+				{
+					Username:   config.Username,
+					Privileges: config.Privileges,
+				},
+			},
+			TagValidationRules: config.TagValidationRules,
+		},
+	}
+	return nil
+}

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	ConfigFile   = "validator.yaml"
+	ConfigFile   = "validatorctl.yaml"
 	TimeFormat   = "20060102150405"
 	WorkspaceLoc = ".validator"
 

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -69,7 +69,6 @@ var (
 	HTTPSchemes           = []string{"https://", "http://"}
 
 	// Command dirs
-	BaseDirs         = []string{"bin"}
 	ValidatorSubdirs = []string{"manifests"}
 
 	// Validator

--- a/pkg/config/manager/config_manager.go
+++ b/pkg/config/manager/config_manager.go
@@ -1,7 +1,6 @@
 package manager
 
 import (
-	"github.com/validator-labs/validatorctl/pkg/cmd/common"
 	cfg "github.com/validator-labs/validatorctl/pkg/config"
 )
 
@@ -12,10 +11,7 @@ func init() {
 }
 
 func Init() error {
-	if err := c.Load(); err != nil {
-		return err
-	}
-	return common.InitWorkspace(c, "", cfg.BaseDirs, false)
+	return c.Load()
 }
 
 func Config() *cfg.Config {


### PR DESCRIPTION
## Description
Setup the following helper functions to easily configure vsphere, oci, and network validator plugins and to generate the validator config file:
- ConfigureBaseValidator(...)
- ConfigureVspherePlugin(...)
- ConfigureNetworkPlugin(...)
- ConfigureOciPlugin(...)

### Other small fixes
- Ensured `ConfigFile` and `ValidatorConfigFile` are not both `validator.yaml`. `ConfigFile` is now `validatorctl.yaml`
- Ensure that the `/bin` base dir is never created. This is not needed because `validatorctl` does not install the helm/docker/kubectl/kind binaries
