### PR TITLE
feat: read CA certs for network rules, add HTTPFileRules, AMIRules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pterm/pterm v0.12.79
 	github.com/sirupsen/logrus v1.9.3
-	github.com/spectrocloud-labs/prompts-tui v0.1.0
 	github.com/spectrocloud-labs/embeddedfs v0.1.0
+	github.com/spectrocloud-labs/prompts-tui v0.1.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	github.com/validator-labs/validator v0.0.50

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pterm/pterm v0.12.79
 	github.com/sirupsen/logrus v1.9.3
-	github.com/spectrocloud-labs/prompts-tui v0.0.0-20240715203051-ec46421ba5c0
+	github.com/spectrocloud-labs/prompts-tui v0.1.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	github.com/validator-labs/validator v0.0.50
@@ -221,4 +221,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-replace github.com/spectrocloud-labs/prompts-tui => ../../spectrocloud-labs/prompts-tui
+// replace github.com/spectrocloud-labs/prompts-tui => ../../spectrocloud-labs/prompts-tui

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/validator-labs/validator v0.0.50
 	github.com/validator-labs/validator-plugin-aws v0.1.2
 	github.com/validator-labs/validator-plugin-azure v0.0.14
-	github.com/validator-labs/validator-plugin-network v0.0.20
+	github.com/validator-labs/validator-plugin-network v0.0.22-0.20240801153219-c280e896939b
 	github.com/validator-labs/validator-plugin-oci v0.0.12
 	github.com/validator-labs/validator-plugin-vsphere v0.0.28
 	github.com/vmware/govmomi v0.39.0
@@ -220,3 +220,5 @@ require (
 	sigs.k8s.io/release-utils v0.8.3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
+
+replace github.com/spectrocloud-labs/prompts-tui => ../../spectrocloud-labs/prompts-tui

--- a/go.sum
+++ b/go.sum
@@ -646,6 +646,8 @@ github.com/smartystreets/assertions v1.1.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYl
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
+github.com/spectrocloud-labs/prompts-tui v0.1.0 h1:8UXUbNZNoEDNZYxAFViCnxznfPRhpS1zhgRWsRN3zOc=
+github.com/spectrocloud-labs/prompts-tui v0.1.0/go.mod h1:XCvyEc3OLxKVXNLbOGZJOR6PiktfWqjYdrwU+ymCmLQ=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=

--- a/go.sum
+++ b/go.sum
@@ -544,8 +544,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/onsi/gomega v1.34.0 h1:eSSPsPNp6ZpsG8X1OVmOTxig+CblTc4AxpPBykhe2Os=
-github.com/onsi/gomega v1.34.0/go.mod h1:MIKI8c+f+QLWk+hxbePD4i0LMJSExPaZOVfkoex4cAo=
+github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
+github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
 github.com/open-policy-agent/opa v0.66.0 h1:DbrvfJQja0FBRcPOB3Z/BOckocN+M4ApNWyNhSRJt0w=
 github.com/open-policy-agent/opa v0.66.0/go.mod h1:EIgNnJcol7AvQR/IcWLwL13k64gHVbNAVG46b2G+/EY=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -646,8 +646,6 @@ github.com/smartystreets/assertions v1.1.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYl
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
-github.com/spectrocloud-labs/prompts-tui v0.0.0-20240715203051-ec46421ba5c0 h1:YdN7sgQxRemJ/EPnVpIGH9Io5yUrSMHKHrcaY8ItO18=
-github.com/spectrocloud-labs/prompts-tui v0.0.0-20240715203051-ec46421ba5c0/go.mod h1:XCvyEc3OLxKVXNLbOGZJOR6PiktfWqjYdrwU+ymCmLQ=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -702,8 +700,8 @@ github.com/validator-labs/validator-plugin-aws v0.1.2 h1:wonvgg9DICxu2fPO3HCTZzC
 github.com/validator-labs/validator-plugin-aws v0.1.2/go.mod h1:oh1xveiGhOgAtlI/okU/sHsOmr4mBbHSLCIoD5essLs=
 github.com/validator-labs/validator-plugin-azure v0.0.14 h1:/PVhAw3Ug4oJz5iRy+Qw8vKYYHd+gOBbXI5AH6GyYHg=
 github.com/validator-labs/validator-plugin-azure v0.0.14/go.mod h1:ik7XNToFzdojBqDM5MUvSRSd+eDJBHJjyfK8uA3J9QY=
-github.com/validator-labs/validator-plugin-network v0.0.20 h1:4jsin7zwblFUFE8lNrSyk+QQj9x0POnndsyDHFjVico=
-github.com/validator-labs/validator-plugin-network v0.0.20/go.mod h1:b1MjI4fQXYin+vFRBHzfpv+vi+b78gO78pGYurkGmd4=
+github.com/validator-labs/validator-plugin-network v0.0.22-0.20240801153219-c280e896939b h1:+6LdYtyCyR25z9FeMYDofDv7bWSI0enSpwZ/moJ8e2A=
+github.com/validator-labs/validator-plugin-network v0.0.22-0.20240801153219-c280e896939b/go.mod h1:ekqx9UjKKF86tspSxuxGJnZWpySTAgV00W1tZHFOoUc=
 github.com/validator-labs/validator-plugin-oci v0.0.12 h1:+mnmiztZDqSyhc2GTZj1yA4Tdax/RVWcimfvj/m+UAs=
 github.com/validator-labs/validator-plugin-oci v0.0.12/go.mod h1:kG1oxwR7ggn1coEF6LIeGPjirwsIjkMkYe0IxIu86pA=
 github.com/validator-labs/validator-plugin-vsphere v0.0.28 h1:t17fAHfYgh6bB6Y/lOssScFmHObOecC9/WuQXwYHAxk=

--- a/pkg/components/validator.go
+++ b/pkg/components/validator.go
@@ -91,7 +91,9 @@ func NewValidatorConfig() *ValidatorConfig {
 				BasicAuth: &BasicAuth{},
 				Data:      make(map[string]string),
 			},
-			Validator: &network.NetworkValidatorSpec{},
+			Validator: &network.NetworkValidatorSpec{
+				CACerts: network.CACertificates{},
+			},
 		},
 		OCIPlugin: &OCIPluginConfig{
 			Release: &validator.HelmRelease{},

--- a/pkg/services/validator/aws.go
+++ b/pkg/services/validator/aws.go
@@ -836,29 +836,9 @@ func readSubnetTagRule(c *components.AWSPluginConfig, r *vpawsapi.TagRule, idx i
 			}
 			r.ARNs[i] = arn
 		}
-		addArns := true
-		if len(r.ARNs) > 0 {
-			addArns, err = prompts.ReadBool("Add another subnet ARN", false)
-			if err != nil {
-				return err
-			}
-		}
-		if addArns {
-			for {
-				arn, err := prompts.ReadText("Subnet ARN", "", false, -1)
-				if err != nil {
-					return err
-				}
-				r.ARNs = append(r.ARNs, arn)
-
-				add, err := prompts.ReadBool("Add another subnet ARN", false)
-				if err != nil {
-					return err
-				}
-				if !add {
-					break
-				}
-			}
+		r.ARNs, err = prompts.ReadTextSlice("Subnet ARNs", strings.Join(r.ARNs, "\n"), "invalid ARNs", "", false)
+		if err != nil {
+			return err
 		}
 		if idx == -1 {
 			c.Validator.TagRules = append(c.Validator.TagRules, *r)

--- a/pkg/services/validator/aws.go
+++ b/pkg/services/validator/aws.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"os"
 	"reflect"
+	"strings"
 	"time"
 
 	"emperror.dev/errors"
@@ -25,7 +26,8 @@ var (
 )
 
 type awsRule interface {
-	*vpawsapi.ServiceQuotaRule | *vpawsapi.TagRule | *vpawsapi.IamRoleRule | *vpawsapi.IamUserRule | *vpawsapi.IamGroupRule | *vpawsapi.IamPolicyRule
+	*vpawsapi.ServiceQuotaRule | *vpawsapi.TagRule | *vpawsapi.AmiRule |
+		*vpawsapi.IamRoleRule | *vpawsapi.IamUserRule | *vpawsapi.IamGroupRule | *vpawsapi.IamPolicyRule
 }
 
 func readAwsPlugin(vc *components.ValidatorConfig, k8sClient kubernetes.Interface) error {
@@ -70,6 +72,9 @@ func readAwsPlugin(vc *components.ValidatorConfig, k8sClient kubernetes.Interfac
 	if err := configureAwsTagRules(c, &ruleNames); err != nil {
 		return err
 	}
+	if err := configureAmiRules(c, &ruleNames); err != nil {
+		return err
+	}
 
 	if c.Validator.ResultCount() == 0 {
 		return errNoRulesEnabled
@@ -84,7 +89,7 @@ func configureIamRoleRules(c *components.AWSPluginConfig, ruleNames *[]string) e
 	specified in the provided policy document(s).
 	`)
 
-	validateRoles, err := prompts.ReadBool("Enable Iam Role validation", true)
+	validateRoles, err := prompts.ReadBool("Enable IAM Role validation", true)
 	if err != nil {
 		return err
 	}
@@ -172,7 +177,7 @@ func configureIamUserRules(c *components.AWSPluginConfig, ruleNames *[]string) e
 	specified in the provided policy document(s).
 	`)
 
-	validateUsers, err := prompts.ReadBool("Enable Iam User validation", true)
+	validateUsers, err := prompts.ReadBool("Enable IAM User validation", true)
 	if err != nil {
 		return err
 	}
@@ -260,7 +265,7 @@ func configureIamGroupRules(c *components.AWSPluginConfig, ruleNames *[]string) 
 	specified in the provided policy document(s).
 	`)
 
-	validateGroups, err := prompts.ReadBool("Enable Iam Group validation", true)
+	validateGroups, err := prompts.ReadBool("Enable IAM Group validation", true)
 	if err != nil {
 		return err
 	}
@@ -348,7 +353,7 @@ func configureIamPolicyRules(c *components.AWSPluginConfig, ruleNames *[]string)
 	specified in the provided policy document(s).
 	`)
 
-	validatePolicies, err := prompts.ReadBool("Enable Iam Policy validation", true)
+	validatePolicies, err := prompts.ReadBool("Enable IAM Policy validation", true)
 	if err != nil {
 		return err
 	}
@@ -599,6 +604,56 @@ func configureAwsTagRules(c *components.AWSPluginConfig, ruleNames *[]string) er
 	return nil
 }
 
+// nolint:dupl
+func configureAmiRules(c *components.AWSPluginConfig, ruleNames *[]string) error {
+	log.InfoCLI(`
+	AMI Rules ensure that one or more EC2 AMIs exist in a particular region.
+	AMIs can be matched by any combination of ID, owner, and filter(s).
+	Each AMI Rule is intended to match a single AMI, as an AmiRule is
+	considered successful if at least one AMI is found.
+	`)
+
+	validateTags, err := prompts.ReadBool("Enable AMI validation", true)
+	if err != nil {
+		return err
+	}
+	if !validateTags {
+		c.Validator.AmiRules = nil
+		return nil
+	}
+	for i, r := range c.Validator.AmiRules {
+		r := r
+		if err := readAmiRule(c, &r, i, ruleNames); err != nil {
+			return err
+		}
+	}
+	addRules := true
+	if c.Validator.AmiRules == nil {
+		c.Validator.AmiRules = make([]vpawsapi.AmiRule, 0)
+	} else {
+		addRules, err = prompts.ReadBool("Add another AMI rule", false)
+		if err != nil {
+			return err
+		}
+	}
+	if !addRules {
+		return nil
+	}
+	for {
+		if err := readAmiRule(c, nil, -1, ruleNames); err != nil {
+			return err
+		}
+		add, err := prompts.ReadBool("Add another AMI rule", false)
+		if err != nil {
+			return err
+		}
+		if !add {
+			break
+		}
+	}
+	return nil
+}
+
 func readAwsCredentials(c *components.AWSPluginConfig, k8sClient kubernetes.Interface) error {
 	var err error
 	c.Validator.Auth.Implicit, err = prompts.ReadBool("Use implicit AWS auth", true)
@@ -820,4 +875,111 @@ func readSubnetTagRule(c *components.AWSPluginConfig, r *vpawsapi.TagRule, idx i
 		}
 	}
 	return nil
+}
+
+func readAmiRule(c *components.AWSPluginConfig, r *vpawsapi.AmiRule, idx int, ruleNames *[]string) error {
+	if r == nil {
+		r = &vpawsapi.AmiRule{
+			Name:    "",
+			AmiIDs:  []string{},
+			Filters: []vpawsapi.Filter{},
+			Owners:  []string{},
+		}
+	}
+	err := initAwsRule(r, "AMI", ruleNames)
+	if err != nil {
+		return err
+	}
+
+	if r.Region != "" {
+		region = r.Region
+	}
+	r.Region, err = prompts.ReadText("AMI Region", region, false, -1)
+	if err != nil {
+		return err
+	}
+
+	log.InfoCLI(`
+	AMI IDs are unique identifiers for Amazon Machine Images. AMI IDs can be omitted
+	if providing filter(s) or owner(s).
+	`)
+	r.AmiIDs, err = prompts.ReadTextSlice("AMI IDs", strings.Join(r.AmiIDs, "\n"), "Invalid AMI", "", true)
+	if err != nil {
+		return err
+	}
+
+	log.InfoCLI(`
+	Filters can be used to match a set of resources by specific criteria, such as tags,
+	attributes, or IDs. See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html
+	for a list of supported filters.
+	`)
+	for _, f := range r.Filters {
+		f := f
+		if err := readFilter(&f); err != nil {
+			return err
+		}
+	}
+	addFilters, err := prompts.ReadBool("Add an AMI filter", false)
+	if err != nil {
+		return err
+	}
+	if addFilters {
+		for {
+			f := vpawsapi.Filter{}
+			if err := readFilter(&f); err != nil {
+				return err
+			}
+			r.Filters = append(r.Filters, f)
+
+			add, err := prompts.ReadBool("Add another filter", false)
+			if err != nil {
+				return err
+			}
+			if !add {
+				break
+			}
+		}
+	}
+
+	log.InfoCLI(`
+	Owners scope the results to images with the specified owners. You can
+	specify a combination of AWS account IDs, self, amazon, and aws-marketplace.
+	If you omit this parameter, the results include all images for which you have
+	launch permissions, regardless of ownership.
+	`)
+	r.Owners, err = prompts.ReadTextSlice("Owners", strings.Join(r.Owners, "\n"), "Invalid Owners", "", true)
+	if err != nil {
+		return err
+	}
+
+	if len(r.AmiIDs) == 0 && len(r.Filters) == 0 && len(r.Owners) == 0 {
+		log.InfoCLI("At least one of AMI IDs, filters, or owners must be provided.")
+		return readAmiRule(c, r, idx, ruleNames)
+	}
+
+	if idx == -1 {
+		c.Validator.AmiRules = append(c.Validator.AmiRules, *r)
+	} else {
+		c.Validator.AmiRules[idx] = *r
+	}
+
+	return nil
+}
+
+func readFilter(f *vpawsapi.Filter) (err error) {
+	f.Key, err = prompts.ReadText("Filter Name", f.Key, false, -1)
+	if err != nil {
+		return
+	}
+	f.Values, err = prompts.ReadTextSlice(
+		"Filter Values", strings.Join(f.Values, "\n"), "Invalid filter values", "", false,
+	)
+	if err != nil {
+		return
+	}
+	f.IsTag, err = prompts.ReadBool("Is this a tag filter", f.IsTag)
+	if err != nil {
+		return
+	}
+	return
 }

--- a/pkg/services/validator/aws_test.go
+++ b/pkg/services/validator/aws_test.go
@@ -65,7 +65,7 @@ func Test_readAwsPlugin(t *testing.T) {
 		},
 	}
 	for _, tt := range tts {
-		prompts.Tui = &mocks.MockTUI{ReturnVals: tt.returnVals}
+		prompts.Tui = &mocks.MockTUI{Values: tt.returnVals}
 		t.Run(tt.name, func(t *testing.T) {
 			err := readAwsPlugin(tt.vc, tt.k8sClient)
 			if (err != nil) != tt.wantErr {

--- a/pkg/services/validator/aws_test.go
+++ b/pkg/services/validator/aws_test.go
@@ -59,6 +59,7 @@ func Test_readAwsPlugin(t *testing.T) {
 				"n",         // enable IAM policy validation
 				"n",         // enable service quota validation
 				"n",         // enable tag validation
+				"n",         // enable AMI validation
 			},
 			wantErr: true,
 			err:     errNoRulesEnabled,

--- a/pkg/services/validator/common.go
+++ b/pkg/services/validator/common.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
 
 	"emperror.dev/errors"
 	"github.com/mohae/deepcopy"
@@ -252,4 +253,13 @@ func intToStringDefault(x int) string {
 		s = strconv.FormatInt(int64(x), 10)
 	}
 	return s
+}
+
+func intsToStringDefault(xs []int) string {
+	ss := make([]string, 0, len(xs))
+	for _, x := range xs {
+		s := strconv.FormatInt(int64(x), 10)
+		ss = append(ss, s)
+	}
+	return strings.Join(ss, "\n")
 }

--- a/pkg/services/validator/network.go
+++ b/pkg/services/validator/network.go
@@ -522,49 +522,18 @@ func readTCPConnRule(c *components.NetworkPluginConfig, r *network.TCPConnRule, 
 	if err != nil {
 		return err
 	}
-	addPorts := true
-	for i, p := range r.Ports {
-		port, err := prompts.ReadInt("Port", intToStringDefault(p), 1, -1)
-		if err != nil {
-			return err
-		}
-		r.Ports[i] = port
+	r.Ports, err = prompts.ReadIntSlice("Port", intsToStringDefault(r.Ports), false)
+	if err != nil {
+		return err
 	}
-	if r.Ports == nil {
-		r.Ports = make([]int, 0)
-	} else {
-		addPorts, err = prompts.ReadBool("Add another port", false)
-		if err != nil {
-			return err
-		}
-	}
-	if addPorts {
-		for {
-			port, err := prompts.ReadInt("Port", "", 1, -1)
-			if err != nil {
-				return err
-			}
-			r.Ports = append(r.Ports, port)
-			add, err := prompts.ReadBool("Add another port", false)
-			if err != nil {
-				return err
-			}
-			if !add {
-				break
-			}
-		}
-	}
-
 	r.InsecureSkipTLSVerify, err = prompts.ReadBool("Skip TLS certificate verification", true)
 	if err != nil {
 		return err
 	}
-
 	r.Timeout, err = prompts.ReadInt("Timeout in seconds", "5", 1, -1)
 	if err != nil {
 		return err
 	}
-
 	if idx == -1 {
 		c.Validator.TCPConnRules = append(c.Validator.TCPConnRules, *r)
 	} else {

--- a/pkg/services/validator/network_test.go
+++ b/pkg/services/validator/network_test.go
@@ -59,7 +59,7 @@ func Test_readNetworkPlugin(t *testing.T) {
 		},
 	}
 	for _, tt := range tts {
-		prompts.Tui = &mocks.MockTUI{ReturnVals: tt.returnVals}
+		prompts.Tui = &mocks.MockTUI{Values: tt.returnVals}
 		t.Run(tt.name, func(t *testing.T) {
 			err := readNetworkPlugin(tt.vc, tt.k8sClient)
 			if (err != nil) != tt.wantErr {

--- a/pkg/services/validator/network_test.go
+++ b/pkg/services/validator/network_test.go
@@ -53,6 +53,7 @@ func Test_readNetworkPlugin(t *testing.T) {
 				"n", // enable IP range validation
 				"n", // enable MTU validation
 				"n", // enable TCP connection validation
+				"n", // enable HTTPFile validation
 			},
 			wantErr: true,
 			err:     errNoRulesEnabled,

--- a/pkg/services/validator/vmware_test.go
+++ b/pkg/services/validator/vmware_test.go
@@ -42,7 +42,7 @@ var (
 
 func setup(returnVals []string) {
 	tui = prompts.Tui
-	prompts.Tui = &tuimocks.MockTUI{ReturnVals: returnVals}
+	prompts.Tui = &tuimocks.MockTUI{Values: returnVals}
 
 	vSphereDriverFunc = clouds.GetVSphereDriver
 	clouds.GetVSphereDriver = func(account *vsphere.CloudAccount) (vsphere.Driver, error) {

--- a/tests/integration/_validator/testcases/test_validator.go
+++ b/tests/integration/_validator/testcases/test_validator.go
@@ -213,8 +213,7 @@ func (t *ValidatorTest) awsPluginValues(ctx *test.TestContext, vals []string, sl
 		"us-west-2",                // subnet tag region #1
 		"foo",                      // subnet tag key #1
 		"bar",                      // subnet tag value #1
-		"baz",                      // subnet arn #1
-		"n",                        // add another subnet arn
+		[]string{"arn-1"},          // subnet arns
 		"n",                        // add another subnet tag rule
 		"n",                        // add another tag rule
 		"y",                        // enable AMI validation
@@ -290,8 +289,7 @@ func (t *ValidatorTest) networkPluginValues(ctx *test.TestContext, vals []string
 		"y",                              // enable TCP connection validation
 		"check tcp",                      // TCP connection rule name
 		"foo",                            // TCP connection host
-		"80",                             // TCP connection port
-		"n",                              // add another port
+		[]string{"80"},                   // TCP connection ports
 		"y",                              // InsecureSkipTLSVerify
 		"5",                              // TCP connection timeout
 		"n",                              // add another TCP connection rule

--- a/tests/integration/_validator/testcases/test_validator.go
+++ b/tests/integration/_validator/testcases/test_validator.go
@@ -122,11 +122,12 @@ func (t *ValidatorTest) testDeployInteractive(ctx *test.TestContext) (tr *test.T
 		"foo",                          // Alertmanager username
 		"bar",                          // Alertmanager password
 	}
+	tuiSliceVals := [][]string{}
 
 	tuiVals = t.baseHelmValues(ctx, tuiVals)
-	tuiVals = t.awsPluginValues(ctx, tuiVals)
+	tuiVals, tuiSliceVals = t.awsPluginValues(ctx, tuiVals, tuiSliceVals)
 	tuiVals = t.azurePluginValues(ctx, tuiVals)
-	tuiVals = t.networkPluginValues(ctx, tuiVals)
+	tuiVals, tuiSliceVals = t.networkPluginValues(ctx, tuiVals, tuiSliceVals)
 	tuiVals = t.ociPluginValues(ctx, tuiVals)
 	tuiVals = t.vspherePluginValues(ctx, tuiVals)
 
@@ -136,7 +137,10 @@ func (t *ValidatorTest) testDeployInteractive(ctx *test.TestContext) (tr *test.T
 		"n", // reconfigure plugin(s)
 	}...)
 
-	prompts.Tui = &tuimocks.MockTUI{ReturnVals: tuiVals}
+	prompts.Tui = &tuimocks.MockTUI{
+		Values:      tuiVals,
+		SliceValues: tuiSliceVals,
+	}
 
 	return common.ExecCLI(interactiveCmd, buffer, t.log)
 }
@@ -158,8 +162,8 @@ func (t *ValidatorTest) baseHelmValues(ctx *test.TestContext, tuiVals []string) 
 	return tuiVals
 }
 
-func (t *ValidatorTest) awsPluginValues(ctx *test.TestContext, tuiVals []string) []string {
-	awsVals := []string{
+func (t *ValidatorTest) awsPluginValues(ctx *test.TestContext, vals []string, sliceVals [][]string) ([]string, [][]string) {
+	awsVals := []any{
 		"y",                         // enable AWS plugin
 		cfg.ValidatorHelmRepository, // validator-plugin-aws helm chart repo
 		"y",                         // Re-use validator chart security configuration
@@ -193,34 +197,43 @@ func (t *ValidatorTest) awsPluginValues(ctx *test.TestContext, tuiVals []string)
 		"n",                         // add another IAM group rule
 		"y",                         // enable IAM policy validation
 		"arn:aws:iam::account-num:policy/some-policy", // IAM policy ARN
-		"Local Filepath",          // Policy Document Source
-		t.filePath("policy.json"), // Policy Document File
-		"n",                       // add another policy document
-		"n",                       // add another IAM policy rule
-		"y",                       // enable service quota validation
-		"EC2",                     // rule name
-		"EC2-VPC Elastic IPs",     // service quota type
-		"us-west-2",               // service quota region #1
-		"5",                       // service quota buffer #1
-		"n",                       // add another service quota rule
-		"y",                       // enable subnet tag validation
-		"subnet",                  // tag resource type
-		"elb tag rule",            // rule name
-		"us-west-2",               // subnet tag region #1
-		"foo",                     // subnet tag key #1
-		"bar",                     // subnet tag value #1
-		"baz",                     // subnet arn #1
-		"n",                       // add another subnet arn
-		"n",                       // add another subnet tag rule
-		"n",                       // add another tag rule
+		"Local Filepath",           // Policy Document Source
+		t.filePath("policy.json"),  // Policy Document File
+		"n",                        // add another policy document
+		"n",                        // add another IAM policy rule
+		"y",                        // enable service quota validation
+		"EC2",                      // rule name
+		"EC2-VPC Elastic IPs",      // service quota type
+		"us-west-2",                // service quota region #1
+		"5",                        // service quota buffer #1
+		"n",                        // add another service quota rule
+		"y",                        // enable subnet tag validation
+		"subnet",                   // tag resource type
+		"elb tag rule",             // rule name
+		"us-west-2",                // subnet tag region #1
+		"foo",                      // subnet tag key #1
+		"bar",                      // subnet tag value #1
+		"baz",                      // subnet arn #1
+		"n",                        // add another subnet arn
+		"n",                        // add another subnet tag rule
+		"n",                        // add another tag rule
+		"y",                        // enable AMI validation
+		"ami rule",                 // rule name
+		"us-west-2",                // ami region
+		[]string{"ami-1", "ami-2"}, // AMI ids
+		"y",                        // add an AMI filter
+		"foo",                      // filter tag
+		[]string{"bar", "baz"},     // filter values
+		"n",                        // is this a tag filter
+		"n",                        // add another filter
+		[]string{""},               // owners
+		"n",                        // add another AMI rule
 	}
 	if string_utils.IsDevVersion(ctx.Get("version")) {
-		awsVals = slices.Insert(awsVals, 2,
-			cfg.ValidatorChartVersions[cfg.ValidatorPluginAws], // validator-plugin-aws helm chart version
-		)
+		awsVals = append(awsVals[:3], awsVals[2:]...)
+		awsVals[2] = cfg.ValidatorChartVersions[cfg.ValidatorPluginAws] // validator-plugin-aws helm chart version
 	}
-	tuiVals = append(tuiVals, awsVals...)
-	return tuiVals
+	return interleave(vals, sliceVals, awsVals)
 }
 
 func (t *ValidatorTest) azurePluginValues(ctx *test.TestContext, tuiVals []string) []string {
@@ -250,46 +263,57 @@ func (t *ValidatorTest) azurePluginValues(ctx *test.TestContext, tuiVals []strin
 	return tuiVals
 }
 
-func (t *ValidatorTest) networkPluginValues(ctx *test.TestContext, tuiVals []string) []string {
-	networkVals := []string{
-		"y",                         // enable Network plugin
-		cfg.ValidatorHelmRepository, // validator-plugin-network helm chart repo
-		"y",                         // Re-use validator chart security configuration
-		"y",                         // enable DNS validation
-		"resolve foo",               // DNS rule name
-		"foo",                       // DNS host
-		"",                          // DNS nameserver
-		"n",                         // add another DNS rule
-		"y",                         // enable ICMP validation
-		"ping foo",                  // ICMP rule name
-		"foo",                       // ICMP host
-		"n",                         // add another ICMP rule
-		"y",                         // enable IP range validation
-		"check ips",                 // IP range rule name
-		"10.10.10.10",               // first IPv4 in range
-		"10",                        // length of IPv4 range
-		"n",                         // add another IP range rule
-		"y",                         // enable MTU validation
-		"check mtu",                 // MTU rule name
-		"foo",                       // MTU host
-		"1500",                      // minimum MTU
-		"n",                         // add another MTU rule
-		"y",                         // enable TCP connection validation
-		"check tcp",                 // TCP connection rule name
-		"foo",                       // TCP connection host
-		"80",                        // TCP connection port
-		"n",                         // add another port
-		"y",                         // InsecureSkipTLSVerify
-		"5",                         // TCP connection timeout
-		"n",                         // add another TCP connection rule
+func (t *ValidatorTest) networkPluginValues(ctx *test.TestContext, vals []string, sliceVals [][]string) ([]string, [][]string) {
+	networkVals := []any{
+		"y",                              // enable Network plugin
+		cfg.ValidatorHelmRepository,      // validator-plugin-network helm chart repo
+		"y",                              // Re-use validator chart security configuration
+		"y",                              // enable DNS validation
+		"resolve foo",                    // DNS rule name
+		"foo",                            // DNS host
+		"",                               // DNS nameserver
+		"n",                              // add another DNS rule
+		"y",                              // enable ICMP validation
+		"ping foo",                       // ICMP rule name
+		"foo",                            // ICMP host
+		"n",                              // add another ICMP rule
+		"y",                              // enable IP range validation
+		"check ips",                      // IP range rule name
+		"10.10.10.10",                    // first IPv4 in range
+		"10",                             // length of IPv4 range
+		"n",                              // add another IP range rule
+		"y",                              // enable MTU validation
+		"check mtu",                      // MTU rule name
+		"foo",                            // MTU host
+		"1500",                           // minimum MTU
+		"n",                              // add another MTU rule
+		"y",                              // enable TCP connection validation
+		"check tcp",                      // TCP connection rule name
+		"foo",                            // TCP connection host
+		"80",                             // TCP connection port
+		"n",                              // add another port
+		"y",                              // InsecureSkipTLSVerify
+		"5",                              // TCP connection timeout
+		"n",                              // add another TCP connection rule
+		"y",                              // enable HTTP file validation
+		[]string{"https://foo.com/file"}, // paths
+		"n",                              // add another path
+		"http-secret",                    // secret name for basic auth
+		"username",                       // username key
+		"password",                       // password key
+		"y",                              // skip TLS verification
+		"n",                              // add another HTTP file rule
+		"n",                              // add local CA certs
+		"y",                              // add CA cert secret refs
+		"ca-certs",                       // secret name
+		"ca.crt",                         // cert key
+		"n",                              // add another CA cert secret ref
 	}
 	if string_utils.IsDevVersion(ctx.Get("version")) {
-		networkVals = slices.Insert(networkVals, 2,
-			cfg.ValidatorChartVersions[cfg.ValidatorPluginNetwork], // validator-plugin-network helm chart version
-		)
+		networkVals = append(networkVals[:3], networkVals[2:]...)
+		networkVals[2] = cfg.ValidatorChartVersions[cfg.ValidatorPluginNetwork] // validator-plugin-network helm chart version
 	}
-	tuiVals = append(tuiVals, networkVals...)
-	return tuiVals
+	return interleave(vals, sliceVals, networkVals)
 }
 
 func (t *ValidatorTest) ociPluginValues(ctx *test.TestContext, tuiVals []string) []string {
@@ -402,6 +426,18 @@ func (t *ValidatorTest) vspherePluginValues(ctx *test.TestContext, tuiVals []str
 	return tuiVals
 }
 
+func interleave(vals []string, sliceVals [][]string, inputVals []any) ([]string, [][]string) {
+	for _, val := range inputVals {
+		switch v := val.(type) {
+		case string:
+			vals = append(vals, v)
+		case []string:
+			sliceVals = append(sliceVals, v)
+		}
+	}
+	return vals, sliceVals
+}
+
 func (t *ValidatorTest) testDeploySilent() (tr *test.TestResult) {
 	if err := t.updateTestData(); err != nil {
 		return test.Failure(err.Error())
@@ -436,7 +472,7 @@ func (t *ValidatorTest) testUpdatePasswords() (tr *test.TestResult) {
 	}
 
 	prompts.Tui = &tuimocks.MockTUI{
-		ReturnVals: []string{
+		Values: []string{
 			// Validator
 			"y",                // Allow Insecure Connection (Bypass x509 Verification)
 			"y",                // Use Helm basic auth


### PR DESCRIPTION
## Issue
Resolves #112

## Description
Add support for reading AMIRules & HTTPFileRules. Also read CA certificates for network plugin rules.

Requires:
- https://github.com/spectrocloud-labs/prompts-tui/pull/7