### PR TITLE
refactor: remove -s flag

### DIFF
--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -53,13 +53,12 @@ For more information about validator, see: https://github.com/validator-labs/val
 	flags.BoolVarP(&tc.Silent, "silent", "s", false, "Skip all plugin prompts and apply configuration file directly. Only applies when --check is set. Default: false.")
 	flags.BoolVar(&tc.Wait, "wait", false, "Wait for validation to succeed and describe results. Only applies when --check is set. Default: false")
 
-	cmd.MarkFlagsMutuallyExclusive("config-only", "wait")
-	cmd.MarkFlagsMutuallyExclusive("update-passwords", "reconfigure")
-
 	cmd.MarkFlagsMutuallyExclusive("config-only", "silent")
 	cmd.MarkFlagsMutuallyExclusive("config-only", "wait")
 	cmd.MarkFlagsMutuallyExclusive("update-passwords", "silent")
 	cmd.MarkFlagsMutuallyExclusive("update-passwords", "wait")
+	cmd.MarkFlagsMutuallyExclusive("update-passwords", "reconfigure")
+	cmd.MarkFlagsMutuallyExclusive("reconfigure", "silent")
 
 	return cmd
 }

--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -50,15 +50,11 @@ For more information about validator, see: https://github.com/validator-labs/val
 	flags.BoolVarP(&tc.Reconfigure, "reconfigure", "r", false, "Re-configure validator and plugin(s) prior to installation. The --config-file flag must be provided. Default: false.")
 
 	flags.BoolVar(&tc.Check, "check", false, "Configure rules for validator plugin(s). Default: false")
-	flags.BoolVarP(&tc.Silent, "silent", "s", false, "Skip all plugin prompts and apply configuration file directly. Only applies when --check is set. Default: false.")
 	flags.BoolVar(&tc.Wait, "wait", false, "Wait for validation to succeed and describe results. Only applies when --check is set. Default: false")
 
-	cmd.MarkFlagsMutuallyExclusive("config-only", "silent")
 	cmd.MarkFlagsMutuallyExclusive("config-only", "wait")
-	cmd.MarkFlagsMutuallyExclusive("update-passwords", "silent")
-	cmd.MarkFlagsMutuallyExclusive("update-passwords", "wait")
 	cmd.MarkFlagsMutuallyExclusive("update-passwords", "reconfigure")
-	cmd.MarkFlagsMutuallyExclusive("reconfigure", "silent")
+	cmd.MarkFlagsMutuallyExclusive("update-passwords", "wait")
 
 	return cmd
 }
@@ -68,8 +64,7 @@ For more information about validator, see: https://github.com/validator-labs/val
 func NewConfigureValidatorCmd() *cobra.Command {
 	c := cfgmanager.Config()
 	var tc = &cfg.TaskConfig{
-		CliVersion:  Version,
-		Reconfigure: true,
+		CliVersion: Version,
 	}
 
 	cmd := &cobra.Command{
@@ -100,15 +95,14 @@ For more information about validator, see: https://github.com/validator-labs/val
 	flags.StringVarP(&tc.ConfigFile, "config-file", "f", "", "Validator installation configuration file.")
 	flags.BoolVarP(&tc.CreateConfigOnly, "config-only", "o", false, "Update configuration file only. Do not proceed with checks. Default: false.")
 	flags.BoolVarP(&tc.UpdatePasswords, "update-passwords", "p", false, "Update passwords only. Do not proceed with checks. Default: false.")
-	flags.BoolVarP(&tc.Silent, "silent", "s", false, "Skip all prompts and apply configuration file directly. Default: false.")
+	flags.BoolVarP(&tc.Reconfigure, "reconfigure", "r", false, "Re-configure plugin rules prior to running checks. Default: false.")
 	flags.BoolVar(&tc.Wait, "wait", false, "Wait for validation to succeed and describe results. Default: false")
 
 	cmdutils.MarkFlagRequired(cmd, "config-file")
 
-	cmd.MarkFlagsMutuallyExclusive("config-only", "silent")
 	cmd.MarkFlagsMutuallyExclusive("config-only", "wait")
-	cmd.MarkFlagsMutuallyExclusive("update-passwords", "silent")
 	cmd.MarkFlagsMutuallyExclusive("update-passwords", "wait")
+	cmd.MarkFlagsMutuallyExclusive("update-passwords", "reconfigure")
 
 	return cmd
 }

--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -92,7 +92,7 @@ For more information about validator, see: https://github.com/validator-labs/val
 	}
 
 	flags := cmd.Flags()
-	flags.StringVarP(&tc.ConfigFile, "config-file", "f", "", "Validator installation configuration file.")
+	flags.StringVarP(&tc.ConfigFile, "config-file", "f", "", "Validator configuration file (required).")
 	flags.BoolVarP(&tc.CreateConfigOnly, "config-only", "o", false, "Update configuration file only. Do not proceed with checks. Default: false.")
 	flags.BoolVarP(&tc.UpdatePasswords, "update-passwords", "p", false, "Update passwords only. Do not proceed with checks. Default: false.")
 	flags.BoolVarP(&tc.Reconfigure, "reconfigure", "r", false, "Re-configure plugin rules prior to running checks. Default: false.")
@@ -101,8 +101,8 @@ For more information about validator, see: https://github.com/validator-labs/val
 	cmdutils.MarkFlagRequired(cmd, "config-file")
 
 	cmd.MarkFlagsMutuallyExclusive("config-only", "wait")
-	cmd.MarkFlagsMutuallyExclusive("update-passwords", "wait")
 	cmd.MarkFlagsMutuallyExclusive("update-passwords", "reconfigure")
+	cmd.MarkFlagsMutuallyExclusive("update-passwords", "wait")
 
 	return cmd
 }

--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -56,6 +56,8 @@ func InstallValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 		log.FatalCLI("Cannot reconfigure validator without providing a configuration file.")
 	}
 
+	configProvided := tc.ConfigFile != ""
+
 	if tc.ConfigFile != "" && !tc.Reconfigure {
 		// Silent Mode
 		vc, err = components.NewValidatorFromConfig(tc)
@@ -118,6 +120,10 @@ func InstallValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 		return err
 	}
 	if tc.Check {
+		if !configProvided {
+			tc.Reconfigure = true
+		}
+
 		return ConfigureValidatorCommand(c, tc)
 	}
 	return nil
@@ -130,7 +136,7 @@ func ConfigureValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 	var err error
 	var saveConfig bool
 
-	if tc.Silent {
+	if !tc.Reconfigure {
 		// Silent Mode
 		vc, err = components.NewValidatorFromConfig(tc)
 		if err != nil {

--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -58,7 +58,7 @@ func InstallValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 
 	configProvided := tc.ConfigFile != ""
 
-	if tc.ConfigFile != "" && !tc.Reconfigure {
+	if configProvided && !tc.Reconfigure {
 		// Silent Mode
 		vc, err = components.NewValidatorFromConfig(tc)
 		if err != nil {

--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -69,6 +69,11 @@ func InstallValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 			if err := validator.UpdateValidatorCredentials(vc); err != nil {
 				return err
 			}
+			if tc.Check {
+				if err := validator.UpdateValidatorPluginCredentials(vc); err != nil {
+					return err
+				}
+			}
 			saveConfig = true
 		}
 		if vc.Kubeconfig == "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,6 @@ type TaskConfig struct {
 	CreateConfigOnly bool
 	DeleteCluster    bool
 	Reconfigure      bool
-	Silent           bool
 	UpdatePasswords  bool
 	Wait             bool
 }

--- a/pkg/services/validator/validator_service.go
+++ b/pkg/services/validator/validator_service.go
@@ -2,6 +2,7 @@
 package validator
 
 import (
+	"fmt"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -347,7 +348,7 @@ func ReadValidatorPluginConfig(c *cfg.Config, tc *cfg.TaskConfig, vc *components
 func UpdateValidatorCredentials(c *components.ValidatorConfig) error {
 	if c.RegistryConfig.Enabled {
 		if err := readRegistryConfig(c); err != nil {
-			return err
+			return fmt.Errorf("failed to update registry config: %w", err)
 		}
 	}
 	k8sClient, err := k8sClientFromConfig(c)
@@ -355,7 +356,7 @@ func UpdateValidatorCredentials(c *components.ValidatorConfig) error {
 		return err
 	}
 	if err := readHelmConfig(cfg.Validator, k8sClient, c, c.ReleaseSecret); err != nil {
-		return err
+		return fmt.Errorf("failed to update Helm configuration: %w", err)
 	}
 	return nil
 }
@@ -368,24 +369,24 @@ func UpdateValidatorPluginCredentials(c *components.ValidatorConfig) error {
 	}
 	if c.AWSPlugin != nil && c.AWSPlugin.Enabled {
 		if err := readAwsCredentials(c.AWSPlugin, k8sClient); err != nil {
-			return err
+			return fmt.Errorf("failed to update AWS credentials: %w", err)
 		}
 	}
 	if c.AzurePlugin != nil && c.AzurePlugin.Enabled {
 		if err := readAzureCredentials(c.AzurePlugin, k8sClient); err != nil {
-			return err
+			return fmt.Errorf("failed to update Azure credentials: %w", err)
 		}
 	}
 	if c.OCIPlugin != nil && c.OCIPlugin.Enabled {
 		for _, secret := range c.OCIPlugin.Secrets {
 			if err := readOciSecret(secret); err != nil {
-				return err
+				return fmt.Errorf("failed to update OCI secret: %w", err)
 			}
 		}
 	}
 	if c.VspherePlugin != nil && c.VspherePlugin.Enabled {
 		if err := readVsphereCredentials(c.VspherePlugin, k8sClient); err != nil {
-			return err
+			return fmt.Errorf("failed to update vSphere credentials: %w", err)
 		}
 	}
 	return nil

--- a/tests/integration/_validator/testcases/test_validator.go
+++ b/tests/integration/_validator/testcases/test_validator.go
@@ -520,7 +520,7 @@ func (t *ValidatorTest) testInstallSilentWait() (tr *test.TestResult) {
 	}
 	silentCmd, buffer := common.InitCmd([]string{
 		"install", "-l", "debug", "-f", t.filePath(cfg.ValidatorConfigFile),
-		"--check", "--silent", "--wait",
+		"--check", "--wait",
 	})
 	return common.ExecCLI(silentCmd, buffer, t.log)
 }


### PR DESCRIPTION
## Description
The proposal of this PR is to simplify our command API by reducing the number of flags we have and using the same flags in different commands.

Namely, this PR focuses on the `--silent` and `--reconfigure` flags. Instead of having both flags available for the `NewInstallValidatorCmd` and `NewConfigureValidatorCmd`, we can reduce to just using the `--reconfigure` flag in both commands.

The implications of these changes are this:
1. No flags passed in => interactive mode
2. If only `-f` is used in either the Install or Configure command => silent mode (ie no TUI prompts)
3. If `-f` and `-r` are used in conjuncture in either the Install or Configure command => reconfigure mode (interactive but with defaults from the config provided to users)
4. If a user runs the install and configure commands in sequence manually (ie without `--check`), they'll need to run the check command as follows to update their plugin rules: `validator check -f validator.yaml -r`

## Tests
Ran the following:
- `validator install --check` => interactive on both install and configure side
- `validator install --check -f validator.yaml` => silent on both install and configure side
- `validator install --check -f validator.yaml -r` => reconfigure mode on both install and configure side