### PR TITLE
refactor: add rules subcommand & split out apply/check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ Use 'validator help <sub-command>' to explore all of the functionality the Valid
 
 	// add base commands
 	rootCmd.AddCommand(NewInstallValidatorCmd())
-	rootCmd.AddCommand(NewConfigureValidatorCmd())
+	rootCmd.AddCommand(NewValidatorRulesCmd())
 	rootCmd.AddCommand(NewUpgradeValidatorCmd())
 	rootCmd.AddCommand(NewUndeployValidatorCmd())
 	rootCmd.AddCommand(NewDescribeValidationResultsCmd())

--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -25,6 +25,21 @@ func NewInstallValidatorCmd() *cobra.Command {
 		Short: "Install validator & validator plugin(s)",
 		Long: `Install validator & validator plugin(s).
 
+The validator CLI will install the validator and any configured plugins
+to a Kubernetes cluster or your choosing.
+
+Optionally provide the --apply and/or --wait flags to configure and apply
+plugin rules and wait for validation, in addition to installation. This
+is equivalent to first running 'validatorctl install', then running 
+'validatorctl rules apply --config-file <config-file> --wait'.
+
+Run 'validatorctl install --reconfigure --config-file <config-file>' to
+reconfigure the validator and plugin(s) prior to installation.
+
+Run 'validatorctl install --update-passwords --config-file <config-file>' to
+update passwords in the validator configuration file. Optionally add
+the --apply flag to update passwords for plugin(s) as well.
+
 For more information about validator, see: https://github.com/validator-labs/validator.
 `,
 		Args:          cobra.NoArgs,
@@ -53,8 +68,8 @@ For more information about validator, see: https://github.com/validator-labs/val
 	flags.BoolVarP(&tc.UpdatePasswords, "update-passwords", "p", false, "Update passwords only. Do not proceed with installation. The --config-file flag must be provided. Default: false.")
 	flags.BoolVarP(&tc.Reconfigure, "reconfigure", "r", false, "Re-configure validator and plugin(s) prior to installation. The --config-file flag must be provided. Default: false.")
 
-	flags.BoolVar(&tc.Check, "check", false, "Configure rules for validator plugin(s). Default: false")
-	flags.BoolVar(&tc.Wait, "wait", false, "Wait for validation to succeed and describe results. Only applies when --check is set. Default: false")
+	flags.BoolVar(&tc.Apply, "apply", false, "Configure and apply validator plugin rules. Default: false")
+	flags.BoolVar(&tc.Wait, "wait", false, "Wait for validation to succeed and describe results. Only applies when --apply is set. Default: false")
 
 	cmd.MarkFlagsMutuallyExclusive("config-only", "wait")
 	cmd.MarkFlagsMutuallyExclusive("update-passwords", "reconfigure")
@@ -63,18 +78,49 @@ For more information about validator, see: https://github.com/validator-labs/val
 	return cmd
 }
 
-// NewConfigureValidatorCmd returns a new cobra command for configuring and applying rules for validator plugins
+// NewValidatorRulesCmd returns a new cobra command which is a container for rule configuration subcommands
 // nolint:dupl
-func NewConfigureValidatorCmd() *cobra.Command {
+func NewValidatorRulesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rules",
+		Short: "Configure & apply, or directly evaluate rules validator plugin rules.",
+		Long: `Configure & apply, or directly evaluate rules validator plugin rules.
+
+To configure and apply validator plugin rules, use 'validatorctl rules apply'.
+Running 'validatorctl rules apply' requires a configuration file, which can be
+generated using 'validatorctl install'.
+
+To directly evaluate validator plugin rules, use 'validatorctl rules check'.
+This does not require a configuration file, but one can be provided if desired.
+
+For more information about validator, see: https://github.com/validator-labs/validator.
+`,
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  false,
+	}
+
+	cmd.AddCommand(NewApplyValidatorCmd())
+	cmd.AddCommand(NewCheckValidatorCmd())
+
+	return cmd
+}
+
+// NewApplyValidatorCmd returns a new cobra command for configuring and applying rules for validator plugins
+func NewApplyValidatorCmd() *cobra.Command {
 	c := cfgmanager.Config()
 	var tc = &cfg.TaskConfig{
 		CliVersion: Version,
 	}
 
 	cmd := &cobra.Command{
-		Use:   "check",
-		Short: "Configure & apply rules for validator plugin(s)",
-		Long: `Configure & apply rules for validator plugin(s).
+		Use:   "apply",
+		Short: "Configure & apply validator plugin rules.",
+		Long: `Configure & apply validator plugin rules.
+
+Plugin-specific custom resources containing rule definitions will be
+generated and applied to a Kubernetes cluster or your choosing. Useful
+for continuous validation and alerting.
 
 For more information about validator, see: https://github.com/validator-labs/validator.
 `,
@@ -82,18 +128,8 @@ For more information about validator, see: https://github.com/validator-labs/val
 		SilenceErrors: true,
 		SilenceUsage:  false,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-			if tc.ConfigFile == "" && !tc.Direct {
-				return fmt.Errorf(`required flag "config-file" not set`)
-			}
-			if !tc.Direct {
-				if err := exec.CheckBinaries([]exec.Binary{exec.HelmBin, exec.KubectlBin}); err != nil {
-					return err
-				}
-			} else {
-				// enables 'validatorctl check --direct' without '-r'
-				if tc.ConfigFile == "" {
-					tc.Reconfigure = true
-				}
+			if err := exec.CheckBinaries([]exec.Binary{exec.HelmBin, exec.KubectlBin}); err != nil {
+				return err
 			}
 			return validator.InitWorkspace(c, cfg.Validator, cfg.ValidatorSubdirs, true)
 		},
@@ -101,8 +137,62 @@ For more information about validator, see: https://github.com/validator-labs/val
 			if err := c.Save(""); err != nil {
 				return err
 			}
-			if err := validator.ConfigureValidatorCommand(c, tc); err != nil {
-				return fmt.Errorf("failed to configure validator: %v", err)
+			if err := validator.ConfigureOrCheckCommand(c, tc); err != nil {
+				return fmt.Errorf("failed to configure and apply validator rules: %v", err)
+			}
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&tc.ConfigFile, "config-file", "f", "", "Validator configuration file (required).")
+	flags.BoolVarP(&tc.CreateConfigOnly, "config-only", "o", false, "Update configuration file only. Do not proceed with checks. Default: false.")
+	flags.BoolVarP(&tc.UpdatePasswords, "update-passwords", "p", false, "Update passwords only. Do not proceed with checks. Default: false.")
+	flags.BoolVarP(&tc.Reconfigure, "reconfigure", "r", false, "Re-configure plugin rules prior to running checks. Default: false.")
+	flags.BoolVar(&tc.Wait, "wait", false, "Wait for validation to succeed and describe results. Default: false")
+
+	cmdutils.MarkFlagRequired(cmd, "config-file")
+
+	cmd.MarkFlagsMutuallyExclusive("config-only", "wait")
+	cmd.MarkFlagsMutuallyExclusive("update-passwords", "reconfigure")
+	cmd.MarkFlagsMutuallyExclusive("update-passwords", "wait")
+
+	return cmd
+}
+
+// NewCheckValidatorCmd returns a new cobra command for directly evaluating rules for validator plugins
+func NewCheckValidatorCmd() *cobra.Command {
+	c := cfgmanager.Config()
+	var tc = &cfg.TaskConfig{
+		CliVersion: Version,
+		Direct:     true,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Directly evaluate rules for validator plugin(s)",
+		Long: `Directly evaluate rules for validator plugin(s).
+
+Plugin rules will be evaluated directly, in-process. Useful for preflight checks or debugging.
+
+For more information about validator, see: https://github.com/validator-labs/validator.
+`,
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  false,
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			// enable 'validatorctl rules check --direct' without '-r'
+			if tc.ConfigFile == "" {
+				tc.Reconfigure = true
+			}
+			return validator.InitWorkspace(c, cfg.Validator, cfg.ValidatorSubdirs, true)
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := c.Save(""); err != nil {
+				return err
+			}
+			if err := validator.ConfigureOrCheckCommand(c, tc); err != nil {
+				return fmt.Errorf("failed to check validator: %v", err)
 			}
 			return nil
 		},
@@ -111,17 +201,10 @@ For more information about validator, see: https://github.com/validator-labs/val
 	flags := cmd.Flags()
 	flags.StringVarP(&tc.ConfigFile, "config-file", "f", "", "Validator configuration file. Required unless using --direct.")
 	flags.BoolVarP(&tc.CreateConfigOnly, "config-only", "o", false, "Update configuration file only. Do not proceed with checks. Default: false.")
-	flags.BoolVarP(&tc.Direct, "direct", "d", false, "Execute checks directly; no validator installation required. Default: false")
 	flags.BoolVarP(&tc.UpdatePasswords, "update-passwords", "p", false, "Update passwords only. Do not proceed with checks. Default: false.")
 	flags.BoolVarP(&tc.Reconfigure, "reconfigure", "r", false, "Re-configure plugin rules prior to running checks. Default: false.")
-	flags.BoolVar(&tc.Wait, "wait", false, "Wait for validation to succeed and describe results. Default: false")
 
-	cmd.MarkFlagsMutuallyExclusive("config-only", "wait")
-	cmd.MarkFlagsMutuallyExclusive("direct", "config-only")
-	cmd.MarkFlagsMutuallyExclusive("direct", "update-passwords")
-	cmd.MarkFlagsMutuallyExclusive("direct", "wait")
 	cmd.MarkFlagsMutuallyExclusive("update-passwords", "reconfigure")
-	cmd.MarkFlagsMutuallyExclusive("update-passwords", "wait")
 
 	return cmd
 }

--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -83,7 +83,7 @@ func InstallValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 			if err := validator.UpdateValidatorCredentials(vc); err != nil {
 				return err
 			}
-			if tc.Check {
+			if tc.Apply {
 				if err := validator.UpdateValidatorPluginCredentials(vc, tc); err != nil {
 					return err
 				}
@@ -138,24 +138,24 @@ func InstallValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 	if err := deployValidatorAndPlugins(c, vc); err != nil {
 		return err
 	}
-	if tc.Check {
+	if tc.Apply {
 		if !configProvided {
 			tc.Reconfigure = true
 		}
-		return ConfigureValidatorCommand(c, tc)
+		return ConfigureOrCheckCommand(c, tc)
 	}
 
 	log.InfoCLI(`
-	Configure plugin rules via the following command:
+	Configure plugin rules and apply them to a cluster via the following command:
 
-	validator check --config-file %s --reconfigure
+	validator rules apply --config-file %s --reconfigure
 	`, tc.ConfigFile)
 	return nil
 }
 
-// ConfigureValidatorCommand configures and applies/executes validator plugin rules
+// ConfigureOrCheckCommand configures and applies/executes validator plugin rules
 // nolint:dupl
-func ConfigureValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
+func ConfigureOrCheckCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 	var vc *components.ValidatorConfig
 	var err error
 	var saveConfig bool

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,7 @@ type Config struct {
 type TaskConfig struct {
 	CliVersion       string
 	ConfigFile       string
-	Check            bool
+	Apply            bool
 	CreateConfigOnly bool
 	DeleteCluster    bool
 	Direct           bool

--- a/pkg/config/versions.go
+++ b/pkg/config/versions.go
@@ -2,7 +2,7 @@ package config
 
 // ValidatorChartVersions is a map of validator component names to their respective versions
 var ValidatorChartVersions = map[string]string{
-	Validator:              "v0.1.1",
+	Validator:              "v0.1.2",
 	ValidatorPluginAws:     "v0.1.3",
 	ValidatorPluginAzure:   "v0.0.15",
 	ValidatorPluginNetwork: "v0.0.22",

--- a/tests/integration/_validator/testcases/data/validator.yaml
+++ b/tests/integration/_validator/testcases/data/validator.yaml
@@ -5,7 +5,7 @@ helmRelease:
   chart:
     name: validator
     repository: validator
-    version: v0.1.1
+    version: v0.1.2
   values: ""
 helmReleaseSecret:
   name: validator-helm-release-validator

--- a/tests/integration/_validator/testcases/test_validator.go
+++ b/tests/integration/_validator/testcases/test_validator.go
@@ -130,7 +130,7 @@ func (t *ValidatorTest) testInstallInteractive(ctx *test.TestContext) (tr *test.
 func (t *ValidatorTest) testInstallInteractiveCheck(ctx *test.TestContext) (tr *test.TestResult) {
 	t.log.Printf("Executing testInstallInteractiveCheck")
 
-	interactiveCmd, buffer := common.InitCmd([]string{"install", "-o", "--check", "-l", "debug"})
+	interactiveCmd, buffer := common.InitCmd([]string{"install", "-o", "--apply", "-l", "debug"})
 
 	// Base values
 	tuiVals := t.validatorValues(ctx)
@@ -528,7 +528,7 @@ func (t *ValidatorTest) testInstallSilentWait() (tr *test.TestResult) {
 	}
 	silentCmd, buffer := common.InitCmd([]string{
 		"install", "-l", "debug", "-f", t.filePath(cfg.ValidatorConfigFile),
-		"--check", "--wait",
+		"--apply", "--wait",
 	})
 	return common.ExecCLI(silentCmd, buffer, t.log)
 }
@@ -546,7 +546,7 @@ func (t *ValidatorTest) testCheckDirect() (tr *test.TestResult) {
 	}
 
 	checkCmd, buffer := common.InitCmd([]string{
-		"check", "-l", "debug", "-f", t.filePath(cfg.ValidatorConfigFile), "--direct",
+		"rules", "check", "-l", "debug", "-f", t.filePath(cfg.ValidatorConfigFile),
 	})
 	return common.ExecCLI(checkCmd, buffer, t.log)
 }


### PR DESCRIPTION
## Issue
N/A

## Description
Add `rules` subcommand with `apply` and `check` subsubcommands to differentiate the application of validator rule CRs vs. direct rule evaluation.
