### PR TITLE
feat: set exit code 2 on validation failure; restore debug log file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,10 +2,14 @@
 package cmd
 
 import (
+	"errors"
+	"os"
+
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/validator-labs/validatorctl/pkg/cmd/validator"
 	cfg "github.com/validator-labs/validatorctl/pkg/config"
 	cfgmanager "github.com/validator-labs/validatorctl/pkg/config/manager"
 	log "github.com/validator-labs/validatorctl/pkg/logging"
@@ -29,9 +33,14 @@ func init() {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		log.FatalCLI("failed to execute command", "error", err)
+	err := rootCmd.Execute()
+	if err == nil {
+		return
 	}
+	if errors.Is(err, validator.ErrValidationFailed{}) {
+		os.Exit(2)
+	}
+	log.FatalCLI("failed to execute command", "error", err)
 }
 
 // InitRootCmd initializes the root command and adds all enabled subcommands

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	k8s.io/apimachinery v0.30.3
 	k8s.io/client-go v0.30.3
 	k8s.io/helm v2.17.0+incompatible
+	sigs.k8s.io/controller-runtime v0.18.4
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -122,6 +123,7 @@ require (
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-jose/go-jose/v4 v4.0.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -246,7 +248,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20240521193020-835d969ad83a // indirect
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0 // indirect
 	sigs.k8s.io/cluster-api v1.7.4 // indirect
-	sigs.k8s.io/controller-runtime v0.18.4 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/release-utils v0.8.4 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -77,7 +77,7 @@ var (
 	RegistryMirrorSeparator = "::"
 
 	// Command dirs
-	ValidatorSubdirs = []string{"manifests"}
+	ValidatorSubdirs = []string{"logs", "manifests"}
 
 	// Validator
 	ValidatorImagePath = func() string {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,4 +1,10 @@
-// Package logging provides a structured logging interface for the CLI.
+// Package logging provides a global logger for the CLI.
+//
+// The global logger's standard methods (i.e., log.Infof, log.Debugf, etc.)
+// write log entries to disk under ~/.validator/logs/validator.log.
+//
+// The ErrorCLI, FatalCLI, and InfoCLI method logs entries to the console.
+// They are used to guide users through an interactive TUI experience.
 package logging
 
 import (
@@ -6,15 +12,13 @@ import (
 	"io"
 	logging "log"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
 	"github.com/pterm/pterm"
 	"github.com/sirupsen/logrus"
 )
-
-// The log.InfoCLI method logs entries to the console. It is used to guide users
-// through an interactive TUI experience.
 
 var (
 	log    *logrus.Logger
@@ -40,6 +44,16 @@ func SetLevel(logLevel string) {
 		logging.Fatalf("error setting log level: %v", err)
 	}
 	log.SetLevel(level)
+}
+
+// SetOutput sets the output location for the logger
+func SetOutput(runLoc string) {
+	logFile := filepath.Join(runLoc, "logs", "validator.log")
+	f, err := os.OpenFile(logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600) //#nosec
+	if err != nil {
+		logging.Fatalf("error opening file: %v", err)
+	}
+	log.SetOutput(f)
 }
 
 // logContext recovers the original caller context of each log message
@@ -137,7 +151,7 @@ func HeaderCustom(s string, bgColor, textColor pterm.Color) {
 	fmt.Fprintf(os.Stdout, "\n") // nolint:errcheck
 }
 
-// Out returns the io.Writer used to write messages to the console
-func Out() *os.File {
-	return os.Stdout
+// Out returns the global logger's io.Writer
+func Out() io.Writer {
+	return log.Out
 }

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,7 +1,7 @@
 // Package logging provides a global logger for the CLI.
 //
-// The global logger's standard methods (i.e., log.Infof, log.Debugf, etc.)
-// write log entries to disk under ~/.validator/logs/validator.log.
+// The global logger's standard methods (i.e., log.Infof, log.Debugf, etc.) write
+// log entries to disk under ~/.validator/validator-<timestamp>/logs/validator.log.
 //
 // The ErrorCLI, FatalCLI, and InfoCLI method logs entries to the console.
 // They are used to guide users through an interactive TUI experience.

--- a/tests/integration/_validator/testcases/test_validator.go
+++ b/tests/integration/_validator/testcases/test_validator.go
@@ -124,7 +124,7 @@ func (t *ValidatorTest) testInstallInteractive(ctx *test.TestContext) (tr *test.
 		Values: tuiVals,
 	}
 
-	return common.ExecCLI(interactiveCmd, buffer, t.log)
+	return common.ExecCLI(interactiveCmd, buffer, t.log, false)
 }
 
 func (t *ValidatorTest) testInstallInteractiveCheck(ctx *test.TestContext) (tr *test.TestResult) {
@@ -157,7 +157,7 @@ func (t *ValidatorTest) testInstallInteractiveCheck(ctx *test.TestContext) (tr *
 		SliceValues: tuiSliceVals,
 	}
 
-	return common.ExecCLI(interactiveCmd, buffer, t.log)
+	return common.ExecCLI(interactiveCmd, buffer, t.log, false)
 }
 
 func (t *ValidatorTest) validatorValues(ctx *test.TestContext) []string {
@@ -514,7 +514,7 @@ func (t *ValidatorTest) testInstallSilent() (tr *test.TestResult) {
 	silentCmd, buffer := common.InitCmd([]string{
 		"install", "-l", "debug", "-f", t.filePath(cfg.ValidatorConfigFile),
 	})
-	return common.ExecCLI(silentCmd, buffer, t.log)
+	return common.ExecCLI(silentCmd, buffer, t.log, false)
 }
 
 func (t *ValidatorTest) testInstallSilentWait() (tr *test.TestResult) {
@@ -530,7 +530,7 @@ func (t *ValidatorTest) testInstallSilentWait() (tr *test.TestResult) {
 		"install", "-l", "debug", "-f", t.filePath(cfg.ValidatorConfigFile),
 		"--apply", "--wait",
 	})
-	return common.ExecCLI(silentCmd, buffer, t.log)
+	return common.ExecCLI(silentCmd, buffer, t.log, false)
 }
 
 func (t *ValidatorTest) testCheckDirect() (tr *test.TestResult) {
@@ -548,7 +548,7 @@ func (t *ValidatorTest) testCheckDirect() (tr *test.TestResult) {
 	checkCmd, buffer := common.InitCmd([]string{
 		"rules", "check", "-l", "debug", "-f", t.filePath(cfg.ValidatorConfigFile),
 	})
-	return common.ExecCLI(checkCmd, buffer, t.log)
+	return common.ExecCLI(checkCmd, buffer, t.log, true)
 }
 
 func (t *ValidatorTest) testDescribe() (tr *test.TestResult) {
@@ -557,7 +557,7 @@ func (t *ValidatorTest) testDescribe() (tr *test.TestResult) {
 	silentCmd, buffer := common.InitCmd([]string{
 		"describe", "-f", t.filePath(cfg.ValidatorConfigFile),
 	})
-	return common.ExecCLI(silentCmd, buffer, t.log)
+	return common.ExecCLI(silentCmd, buffer, t.log, false)
 }
 
 func (t *ValidatorTest) testUndeploy() (tr *test.TestResult) {
@@ -566,7 +566,7 @@ func (t *ValidatorTest) testUndeploy() (tr *test.TestResult) {
 	silentCmd, buffer := common.InitCmd([]string{
 		"uninstall", "-f", t.filePath(cfg.ValidatorConfigFile),
 	})
-	return common.ExecCLI(silentCmd, buffer, t.log)
+	return common.ExecCLI(silentCmd, buffer, t.log, false)
 }
 
 func (t *ValidatorTest) testInstallUpdatePasswords() (tr *test.TestResult) {
@@ -623,7 +623,7 @@ func (t *ValidatorTest) testInstallUpdatePasswords() (tr *test.TestResult) {
 		},
 	}
 
-	return common.ExecCLI(cmd, buffer, t.log)
+	return common.ExecCLI(cmd, buffer, t.log, false)
 }
 
 func (t *ValidatorTest) PreRequisite(ctx *test.TestContext) (tr *test.TestResult) {

--- a/tests/integration/common/cli_commands.go
+++ b/tests/integration/common/cli_commands.go
@@ -2,15 +2,19 @@ package common
 
 import (
 	"bytes"
+	"errors"
 	"io"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/validator-labs/validatorctl/cmd"
+	"github.com/validator-labs/validatorctl/pkg/cmd/validator"
 	"github.com/validator-labs/validatorctl/tests/utils/test"
 )
 
+// InitCmd initializes a new cobra command with the given arguments
+// and returns the command and a buffer to capture the output.
 func InitCmd(args []string) (*cobra.Command, *bytes.Buffer) {
 	b := bytes.NewBufferString("")
 	rootCmd := cmd.InitRootCmd()
@@ -19,9 +23,13 @@ func InitCmd(args []string) (*cobra.Command, *bytes.Buffer) {
 	return rootCmd, b
 }
 
-func ExecCLI(cmd *cobra.Command, buffer *bytes.Buffer, log *log.Entry) (tr *test.TestResult) {
+// ExecCLI executes the given cobra command and returns a test result.
+func ExecCLI(cmd *cobra.Command, buffer *bytes.Buffer, log *log.Entry, expectValidationErr bool) (tr *test.TestResult) {
 	if err := cmd.Execute(); err != nil {
-		return test.Failure(err.Error())
+		isValidationFailed := errors.Is(err, validator.ErrValidationFailed{})
+		if !isValidationFailed || (isValidationFailed && !expectValidationErr) {
+			return test.Failure(err.Error())
+		}
 	}
 	out, err := io.ReadAll(buffer)
 	if err != nil {


### PR DESCRIPTION
## Issue
Resolves #138 

## Description
- Set exit code 2 for `validator rules check` if validation fails for any rule.
- Document exit codes.
- Re-enable logging to disk under unique log directory per `validatorctl` execution.
