### PR TITLE
fix: correct TUI flow for `validator install -o --apply`

### DIFF
--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -137,6 +137,15 @@ func InstallValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 		log.InfoCLI("validator configuration file: %s", tc.ConfigFile)
 	}
 
+	if tc.Apply {
+		if !configProvided {
+			tc.Reconfigure = true
+		}
+		if err := ConfigureOrCheckCommand(c, tc); err != nil {
+			return err
+		}
+	}
+
 	if tc.CreateConfigOnly || tc.UpdatePasswords {
 		return nil
 	}
@@ -149,12 +158,6 @@ func InstallValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 
 	if err := deployValidatorAndPlugins(c, vc); err != nil {
 		return err
-	}
-	if tc.Apply {
-		if !configProvided {
-			tc.Reconfigure = true
-		}
-		return ConfigureOrCheckCommand(c, tc)
 	}
 
 	log.InfoCLI(`

--- a/pkg/services/clouds/maas_service.go
+++ b/pkg/services/clouds/maas_service.go
@@ -107,12 +107,36 @@ func GetMaasZones(c *components.MaasPluginConfig) ([]string, error) {
 	return zones, nil
 }
 
-func getMaasClient(maasURL, maasToken string) (*maasclient.Client, error) {
-	client, err := maasclient.GetClient(maasURL, maasToken, "2.0")
+func getMaasClient(url, token string) (*maasclient.Client, error) {
+	client, err := maasclient.GetClient(url, token, "2.0")
 	if err != nil {
 		return &maasclient.Client{}, err
 	}
 	return client, nil
+}
+
+// GetMockMaasClient returns a mock MAAS client for testing
+func GetMockMaasClient(_, _ string) (*maasclient.Client, error) {
+	mockClient := &maasclient.Client{
+		Account: &MockMaasAccount{},
+		ResourcePools: &MockMaasResourcePools{
+			resourcePools: []entity.ResourcePool{
+				{
+					Name: "pool1",
+					ID:   1,
+				},
+			},
+		},
+		Zones: &MockMaasZones{
+			zones: []entity.Zone{
+				{
+					Name: "az1",
+					ID:   1,
+				},
+			},
+		},
+	}
+	return mockClient, nil
 }
 
 // MockMaasAccount replaces the maasclient.Account struct for integration testing
@@ -123,4 +147,26 @@ type MockMaasAccount struct {
 // ListAuthorisationTokens replaces the maasclient.Account.ListAuthorisationTokens method for integration testing
 func (a *MockMaasAccount) ListAuthorisationTokens() ([]entity.AuthorisationTokenListItem, error) {
 	return []entity.AuthorisationTokenListItem{}, nil
+}
+
+// MockMaasResourcePools replaces the maasclient.ResourcePools struct for integration testing
+type MockMaasResourcePools struct {
+	maasclient.ResourcePools
+	resourcePools []entity.ResourcePool
+}
+
+// Get replaces the maasclient.ResourcePools.Get method for integration testing
+func (r *MockMaasResourcePools) Get() ([]entity.ResourcePool, error) {
+	return r.resourcePools, nil
+}
+
+// MockMaasZones replaces the maasclient.Zones struct for integration testing
+type MockMaasZones struct {
+	maasclient.Zones
+	zones []entity.Zone
+}
+
+// Get replaces the maasclient.Zones.Get method for integration testing
+func (z *MockMaasZones) Get() ([]entity.Zone, error) {
+	return z.zones, nil
 }

--- a/pkg/services/validator/aws.go
+++ b/pkg/services/validator/aws.go
@@ -111,7 +111,7 @@ func configureIamRoleRules(c *components.AWSPluginConfig, ruleNames *[]string) e
 		}
 	}
 	addRules := true
-	if c.Validator.IamRoleRules == nil {
+	if len(c.Validator.IamRoleRules) == 0 {
 		c.Validator.IamRoleRules = make([]vpawsapi.IamRoleRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another role rule", false)
@@ -200,7 +200,7 @@ func configureIamUserRules(c *components.AWSPluginConfig, ruleNames *[]string) e
 		}
 	}
 	addRules := true
-	if c.Validator.IamUserRules == nil {
+	if len(c.Validator.IamUserRules) == 0 {
 		c.Validator.IamUserRules = make([]vpawsapi.IamUserRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another user rule", false)
@@ -289,7 +289,7 @@ func configureIamGroupRules(c *components.AWSPluginConfig, ruleNames *[]string) 
 		}
 	}
 	addRules := true
-	if c.Validator.IamGroupRules == nil {
+	if len(c.Validator.IamGroupRules) == 0 {
 		c.Validator.IamGroupRules = make([]vpawsapi.IamGroupRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another group rule", false)
@@ -378,7 +378,7 @@ func configureIamPolicyRules(c *components.AWSPluginConfig, ruleNames *[]string)
 		}
 	}
 	addRules := true
-	if c.Validator.IamPolicyRules == nil {
+	if len(c.Validator.IamPolicyRules) == 0 {
 		c.Validator.IamPolicyRules = make([]vpawsapi.IamPolicyRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another policy rule", false)
@@ -531,7 +531,7 @@ func configureServiceQuotaRules(c *components.AWSPluginConfig, ruleNames *[]stri
 		}
 	}
 	addRules := true
-	if c.Validator.ServiceQuotaRules == nil {
+	if len(c.Validator.ServiceQuotaRules) == 0 {
 		c.Validator.ServiceQuotaRules = make([]vpawsapi.ServiceQuotaRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another service quota rule", false)
@@ -580,7 +580,7 @@ func configureAwsTagRules(c *components.AWSPluginConfig, ruleNames *[]string) er
 		}
 	}
 	addRules := true
-	if c.Validator.TagRules == nil {
+	if len(c.Validator.TagRules) == 0 {
 		c.Validator.TagRules = make([]vpawsapi.TagRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another subnet tag rule", false)
@@ -637,7 +637,7 @@ func configureAmiRules(c *components.AWSPluginConfig, ruleNames *[]string) error
 		}
 	}
 	addRules := true
-	if c.Validator.AmiRules == nil {
+	if len(c.Validator.AmiRules) == 0 {
 		c.Validator.AmiRules = make([]vpawsapi.AmiRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another AMI rule", false)

--- a/pkg/services/validator/azure.go
+++ b/pkg/services/validator/azure.go
@@ -143,7 +143,7 @@ func configureAzureRBACRules(c *components.AzurePluginConfig) error {
 		c.Validator.RBACRules[i] = r
 	}
 
-	if c.Validator.RBACRules == nil {
+	if len(c.Validator.RBACRules) == 0 {
 		c.Validator.RBACRules = make([]plug.RBACRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another RBAC rule", false)

--- a/pkg/services/validator/maas.go
+++ b/pkg/services/validator/maas.go
@@ -168,7 +168,7 @@ func configureMaasResourceRules(c *components.MaasPluginConfig, ruleNames *[]str
 	}
 
 	addRules := true
-	if c.Validator.ResourceAvailabilityRules == nil {
+	if len(c.Validator.ResourceAvailabilityRules) == 0 {
 		c.Validator.ResourceAvailabilityRules = make([]vpmaasapi.ResourceAvailabilityRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another Resource Availability rule", false)
@@ -319,7 +319,7 @@ func configureMaasImageRules(c *components.MaasPluginConfig, ruleNames *[]string
 	}
 
 	addRules := true
-	if c.Validator.ImageRules == nil {
+	if len(c.Validator.ImageRules) == 0 {
 		c.Validator.ImageRules = make([]vpmaasapi.ImageRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another OS Image rule", false)
@@ -423,7 +423,7 @@ func configureMaasInternalDNSRules(c *components.MaasPluginConfig, ruleNames *[]
 	}
 
 	addRules := true
-	if c.Validator.InternalDNSRules == nil {
+	if len(c.Validator.InternalDNSRules) == 0 {
 		c.Validator.InternalDNSRules = make([]vpmaasapi.InternalDNSRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another Internal DNS rule", false)
@@ -569,7 +569,7 @@ func configureMaasUpstreamDNSRules(c *components.MaasPluginConfig, ruleNames *[]
 	}
 
 	addRules := true
-	if c.Validator.UpstreamDNSRules == nil {
+	if len(c.Validator.UpstreamDNSRules) == 0 {
 		c.Validator.UpstreamDNSRules = make([]vpmaasapi.UpstreamDNSRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another Upstream DNS rule", false)

--- a/pkg/services/validator/network.go
+++ b/pkg/services/validator/network.go
@@ -166,7 +166,7 @@ func configureDNSRules(c *components.NetworkPluginConfig, ruleNames *[]string) e
 		}
 	}
 	addRules := true
-	if c.Validator.DNSRules == nil {
+	if len(c.Validator.DNSRules) == 0 {
 		c.Validator.DNSRules = make([]network.DNSRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another DNS rule", false)
@@ -213,7 +213,7 @@ func configureIcmpRules(c *components.NetworkPluginConfig, ruleNames *[]string) 
 		}
 	}
 	addRules := true
-	if c.Validator.ICMPRules == nil {
+	if len(c.Validator.ICMPRules) == 0 {
 		c.Validator.ICMPRules = make([]network.ICMPRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another ICMP rule", false)
@@ -261,7 +261,7 @@ func configureIPRangeRules(c *components.NetworkPluginConfig, ruleNames *[]strin
 		}
 	}
 	addRules := true
-	if c.Validator.IPRangeRules == nil {
+	if len(c.Validator.IPRangeRules) == 0 {
 		c.Validator.IPRangeRules = make([]network.IPRangeRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another IP range rule", false)
@@ -309,7 +309,7 @@ func configureMtuRules(c *components.NetworkPluginConfig, ruleNames *[]string) e
 		}
 	}
 	addRules := true
-	if c.Validator.MTURules == nil {
+	if len(c.Validator.MTURules) == 0 {
 		c.Validator.MTURules = make([]network.MTURule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another MTU rule", false)
@@ -357,7 +357,7 @@ func configureTCPConnRules(c *components.NetworkPluginConfig, ruleNames *[]strin
 		}
 	}
 	addRules := true
-	if c.Validator.TCPConnRules == nil {
+	if len(c.Validator.TCPConnRules) == 0 {
 		c.Validator.TCPConnRules = make([]network.TCPConnRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another TCP connection rule", false)
@@ -405,7 +405,7 @@ func configureHTTPFileRules(c *components.NetworkPluginConfig, tc *cfg.TaskConfi
 		}
 	}
 	addRules := true
-	if c.Validator.HTTPFileRules == nil {
+	if len(c.Validator.HTTPFileRules) == 0 {
 		c.Validator.HTTPFileRules = make([]network.HTTPFileRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another HTTP file rule", false)

--- a/pkg/services/validator/oci.go
+++ b/pkg/services/validator/oci.go
@@ -230,7 +230,7 @@ func configureOciRegistryRules(c *components.OCIPluginConfig, authSecretNames, s
 		}
 	}
 
-	if c.Validator.OciRegistryRules == nil {
+	if len(c.Validator.OciRegistryRules) == 0 {
 		c.Validator.OciRegistryRules = make([]plug.OciRegistryRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another OCI registry rule", false)

--- a/pkg/services/validator/validator_service.go
+++ b/pkg/services/validator/validator_service.go
@@ -373,7 +373,7 @@ func ReadValidatorPluginConfig(c *cfg.Config, tc *cfg.TaskConfig, vc *components
 
 	if tc.Direct {
 		enablePlugins = true
-	} else {
+	} else if !tc.CreateConfigOnly {
 		if vc.Kubeconfig == "" {
 			if vc.KindConfig.UseKindCluster {
 				return errors.New(`config file has kindConfig.useKindCluster set to true, but no kubeconfig path was provided. Have you run "validator install" yet?`)

--- a/pkg/services/validator/vmware.go
+++ b/pkg/services/validator/vmware.go
@@ -205,7 +205,7 @@ func configureNtpRules(ctx context.Context, c *components.VspherePluginConfig, d
 		}
 	}
 	addRules := true
-	if c.Validator.NTPValidationRules == nil {
+	if len(c.Validator.NTPValidationRules) == 0 {
 		c.Validator.NTPValidationRules = make([]v1alpha1.NTPValidationRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another NTP validation rule", false)
@@ -315,7 +315,7 @@ func configureRolePrivilegeRules(c *components.VspherePluginConfig, ruleNames *[
 		}
 	}
 	addRules := true
-	if c.VsphereRolePrivilegeRules == nil {
+	if len(c.VsphereRolePrivilegeRules) == 0 {
 		c.VsphereRolePrivilegeRules = make([]components.VsphereRolePrivilegeRule, 0)
 		c.Validator.RolePrivilegeValidationRules = make([]v1alpha1.GenericRolePrivilegeValidationRule, 0)
 	} else {
@@ -403,6 +403,9 @@ func loadPrivileges(privilegeFile string) (string, func(string) error, error) {
 	slices.Sort(privileges)
 
 	validate := func(input string) error {
+		if strings.HasPrefix(input, "#") {
+			return nil
+		}
 		if !slices.Contains(privileges, strings.TrimSpace(input)) {
 			log.ErrorCLI("failed to read vCenter privileges", "invalidPrivilege", input)
 			return prompts.ErrValidationFailed
@@ -508,7 +511,7 @@ func configureEntityPrivilegeRules(ctx context.Context, c *components.VspherePlu
 		}
 	}
 	addRules := true
-	if c.Validator.EntityPrivilegeValidationRules == nil {
+	if len(c.Validator.EntityPrivilegeValidationRules) == 0 {
 		c.VsphereEntityPrivilegeRules = make([]components.VsphereEntityPrivilegeRule, 0)
 		c.Validator.EntityPrivilegeValidationRules = make([]v1alpha1.EntityPrivilegeValidationRule, 0)
 	} else {
@@ -617,7 +620,7 @@ func configureResourceRequirementRules(ctx context.Context, c *components.Vspher
 		}
 	}
 	addRules := true
-	if c.Validator.ComputeResourceRules == nil {
+	if len(c.Validator.ComputeResourceRules) == 0 {
 		c.Validator.ComputeResourceRules = make([]v1alpha1.ComputeResourceRule, 0)
 	} else {
 		addRules, err = prompts.ReadBool("Add another resource requirement validation rule", false)
@@ -756,7 +759,7 @@ func configureVsphereTagRules(ctx context.Context, c *components.VspherePluginCo
 		}
 	}
 	addRules := true
-	if c.VsphereTagRules == nil {
+	if len(c.VsphereTagRules) == 0 {
 		c.VsphereTagRules = make([]components.VsphereTagRule, 0)
 		c.Validator.TagValidationRules = make([]v1alpha1.TagValidationRule, 0)
 	} else {


### PR DESCRIPTION
## Issue
N/A

## Description
Sometime during the CLI refactor, the E2E flow for prompting users for installation & rule config in a single pass in config-only mode was broken. This PR fixes that and addresses various issues with integration test prompting and dummy values that were previously missed as a result of the broken TUI flow.
