### PR TITLE
fix: ensure ErrValidationFailed is returned for maas direct validation failures

### DIFF
--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -565,6 +565,9 @@ func executePlugins(c *cfg.Config, vc *components.ValidatorConfig) error {
 		if err := vres.Finalize(vr, vrr, l); err != nil {
 			return err
 		}
+		if vrOk := validationResponseOk(vrr, l); !vrOk {
+			ok = false
+		}
 		results = append(results, vr)
 	}
 


### PR DESCRIPTION
## Issue
N/A

## Description
When running `validator rules check`, we werent properly setting the validationSuccess variable (ok) to false.