### PR TITLE
fix: only require docker, kind when provisioning kind cluster

### DIFF
--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -47,7 +47,7 @@ For more information about validator, see: https://github.com/validator-labs/val
 		SilenceErrors: true,
 		SilenceUsage:  false,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-			if err := exec.CheckBinaries(exec.AllBins); err != nil {
+			if err := exec.CheckBinaries([]exec.Binary{exec.HelmBin, exec.KubectlBin}); err != nil {
 				return err
 			}
 			return validator.InitWorkspace(c, cfg.Validator, cfg.ValidatorSubdirs, true)
@@ -268,7 +268,7 @@ func NewUndeployValidatorCmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  false,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-			if err := exec.CheckBinaries([]exec.Binary{exec.HelmBin, exec.KindBin}); err != nil {
+			if err := exec.CheckBinaries([]exec.Binary{exec.HelmBin}); err != nil {
 				return err
 			}
 			return validator.InitWorkspace(c, cfg.Validator, cfg.ValidatorSubdirs, true)

--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -49,6 +49,7 @@ import (
 	log "github.com/validator-labs/validatorctl/pkg/logging"
 	"github.com/validator-labs/validatorctl/pkg/services/validator"
 	"github.com/validator-labs/validatorctl/pkg/utils/embed"
+	"github.com/validator-labs/validatorctl/pkg/utils/exec"
 	exec_utils "github.com/validator-labs/validatorctl/pkg/utils/exec"
 	"github.com/validator-labs/validatorctl/pkg/utils/kind"
 	"github.com/validator-labs/validatorctl/pkg/utils/kube"
@@ -89,6 +90,11 @@ func InstallValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 		vc, err = components.NewValidatorFromConfig(tc)
 		if err != nil {
 			return errors.Wrap(err, "failed to load validator configuration file")
+		}
+		if vc.KindConfig.UseKindCluster {
+			if err := exec.CheckBinaries([]exec.Binary{exec.DockerBin, exec.KindBin}); err != nil {
+				return err
+			}
 		}
 		if tc.UpdatePasswords {
 			log.Header("Updating credentials in validator configuration file")
@@ -271,6 +277,11 @@ func UndeployValidatorCommand(tc *cfg.TaskConfig) error {
 	vc, err := components.NewValidatorFromConfig(tc)
 	if err != nil {
 		return errors.Wrap(err, "failed to load validator configuration file")
+	}
+	if vc.KindConfig.UseKindCluster && tc.DeleteCluster {
+		if err := exec.CheckBinaries([]exec.Binary{exec.KindBin}); err != nil {
+			return err
+		}
 	}
 
 	log.Header("Uninstalling validator")

--- a/pkg/services/validator/validator_service.go
+++ b/pkg/services/validator/validator_service.go
@@ -86,6 +86,9 @@ func ReadValidatorConfig(c *cfg.Config, tc *cfg.TaskConfig, vc *components.Valid
 		return err
 	}
 	if vc.KindConfig.UseKindCluster {
+		if err := exec.CheckBinaries([]exec.Binary{exec.DockerBin, exec.KindBin}); err != nil {
+			return err
+		}
 		if err := kind.ValidateClusters("Validator installation"); err != nil {
 			return err
 		}

--- a/pkg/utils/exec/exec.go
+++ b/pkg/utils/exec/exec.go
@@ -50,9 +50,6 @@ var (
 	Ping string
 	// PingBin is a Binary struct that references the ping binary.
 	PingBin = Binary{"ping", &Ping}
-
-	// AllBins is a list of all binaries used by the CLI.
-	AllBins = []Binary{DockerBin, HelmBin, KindBin, KubectlBin}
 )
 
 // CheckBinaries checks if the required binaries are installed and available on the PATH and returns an error if any are missing.


### PR DESCRIPTION
## Issue
N/A

## Description
Fixes a bug where docker and kind were considered mandatory even when using an existing k8s cluster.

Verify binaries and exit as early as possible if appropriate.
