### PR TITLE
feat: support Azure plugin community gallery image rule

### DIFF
--- a/pkg/components/validator.go
+++ b/pkg/components/validator.go
@@ -74,11 +74,8 @@ func NewValidatorConfig() *ValidatorConfig {
 			Validator: &aws.AwsValidatorSpec{},
 		},
 		AzurePlugin: &AzurePluginConfig{
-			Release:                &validator.HelmRelease{},
-			Validator:              &azure.AzureValidatorSpec{},
-			RuleTypes:              make(map[int]string),
-			StaticDeploymentTypes:  make(map[int]string),
-			StaticDeploymentValues: make(map[int]*AzureStaticDeploymentValues),
+			Release:   &validator.HelmRelease{},
+			Validator: &azure.AzureValidatorSpec{},
 		},
 		MaasPlugin: &MaasPluginConfig{
 			Release:   &validator.HelmRelease{},
@@ -372,17 +369,14 @@ func (c *AWSPluginConfig) decrypt() error {
 
 // AzurePluginConfig represents the Azure plugin configuration.
 type AzurePluginConfig struct {
-	Enabled                bool                                 `yaml:"enabled"`
-	Release                *validator.HelmRelease               `yaml:"helmRelease"`
-	ServiceAccountName     string                               `yaml:"serviceAccountName,omitempty"`
-	Cloud                  string                               `yaml:"cloud"`
-	TenantID               string                               `yaml:"tenantId"`
-	ClientID               string                               `yaml:"clientId"`
-	ClientSecret           string                               `yaml:"clientSecret"`
-	RuleTypes              map[int]string                       `yaml:"ruleTypes"`
-	StaticDeploymentTypes  map[int]string                       `yaml:"staticDeploymentTypes"`
-	StaticDeploymentValues map[int]*AzureStaticDeploymentValues `yaml:"staticDeploymentValues"`
-	Validator              *azure.AzureValidatorSpec            `yaml:"validator"`
+	Enabled            bool                      `yaml:"enabled"`
+	Release            *validator.HelmRelease    `yaml:"helmRelease"`
+	ServiceAccountName string                    `yaml:"serviceAccountName,omitempty"`
+	Cloud              string                    `yaml:"cloud"`
+	TenantID           string                    `yaml:"tenantId"`
+	ClientID           string                    `yaml:"clientId"`
+	ClientSecret       string                    `yaml:"clientSecret"`
+	Validator          *azure.AzureValidatorSpec `yaml:"validator"`
 }
 
 func (c *AzurePluginConfig) encrypt() error {
@@ -403,15 +397,6 @@ func (c *AzurePluginConfig) decrypt() error {
 	c.ClientSecret = string(*bytes)
 
 	return nil
-}
-
-// AzureStaticDeploymentValues represents the static deployment values for Azure.
-type AzureStaticDeploymentValues struct {
-	Subscription   string `yaml:"subscriptionUuid"`
-	ResourceGroup  string `yaml:"resourceGroupUuid"`
-	VirtualNetwork string `yaml:"virtualNetworkUuid"`
-	Subnet         string `yaml:"subnetUuid"`
-	ComputeGallery string `yaml:"computeGalleryUuid"`
 }
 
 // MaasPluginConfig represents the MAAS plugin configuration.

--- a/pkg/services/validator/azure.go
+++ b/pkg/services/validator/azure.go
@@ -411,7 +411,7 @@ func readCommunityGalleryImageRule(c *components.AzurePluginConfig, r *plug.Comm
 		return fmt.Errorf("failed to prompt for images: %w", err)
 	}
 
-	log.InfoCLI("The subscription ID is that of the subscription that should have access to the gallery.")
+	log.InfoCLI("Community gallery images are accessed via subscriptions. You must provide the ID of the subscription you want to verify that community gallery image can be accessed with. This can be any subscription the security principal you authed the Azure plugin with has access to.")
 	logToCollect("subscription ID", formatAzureGUID)
 	if r.SubscriptionID, err = prompts.ReadTextRegex("Subscription ID", r.SubscriptionID, mustBeValidUUID, prompts.UUIDRegex); err != nil {
 		return err

--- a/pkg/services/validator/azure.go
+++ b/pkg/services/validator/azure.go
@@ -199,6 +199,7 @@ func readAzureCredsHelper(c *components.AzurePluginConfig) error {
 }
 
 // configureRBACRules sets up zero or more RBAC rules based on pre-existing files or user input.
+// nolint:dupl
 func configureRBACRules(c *components.AzurePluginConfig, ruleNames *[]string) error {
 	log.InfoCLI(`
 	RBAC validation rules ensure that security principals have the required permissions.

--- a/pkg/services/validator/azure.go
+++ b/pkg/services/validator/azure.go
@@ -418,9 +418,11 @@ func readCommunityGalleryImageRule(c *components.AzurePluginConfig, r *plug.Comm
 		return fmt.Errorf("failed to prompt for images: %w", err)
 	}
 
-	log.InfoCLI(`Community gallery images are accessed via subscriptions.
-You must provide the ID of the subscription you want to verify that community gallery image can be accessed with.
-This can be any subscription the security principal you authed the Azure plugin with has access to.`)
+	log.InfoCLI(`
+ 	Community gallery images are accessed via subscriptions.
+	Provide the ID of the subscription you want to verify can access the community gallery image(s).
+	This can be any subscription the security principal you authed the Azure plugin with has access to.
+	`)
 	logToCollect("subscription ID", formatAzureGUID)
 	if r.SubscriptionID, err = prompts.ReadTextRegex("Subscription ID", r.SubscriptionID, mustBeValidUUID, prompts.UUIDRegex); err != nil {
 		return err

--- a/tests/integration/_validator/testcases/test_validator.go
+++ b/tests/integration/_validator/testcases/test_validator.go
@@ -149,7 +149,7 @@ func (t *ValidatorTest) testInstallInteractiveApply(ctx *test.TestContext) (tr *
 	// Plugin values
 	tuiSliceVals := make([][]string, 0)
 	tuiVals, tuiSliceVals = t.awsPluginValues(ctx, tuiVals, tuiSliceVals)
-	tuiVals = t.azurePluginValues(ctx, tuiVals)
+	tuiVals, tuiSliceVals = t.azurePluginValues(ctx, tuiVals, tuiSliceVals)
 	tuiVals, tuiSliceVals = t.maasPluginValues(ctx, tuiVals, tuiSliceVals)
 	tuiVals, tuiSliceVals = t.networkPluginValues(ctx, tuiVals, tuiSliceVals)
 	tuiVals, tuiSliceVals = t.ociPluginValues(ctx, tuiVals, tuiSliceVals)
@@ -307,16 +307,25 @@ func (t *ValidatorTest) azurePluginInstallValues(ctx *test.TestContext, vals []s
 	return vals
 }
 
-func (t *ValidatorTest) azurePluginValues(ctx *test.TestContext, vals []string) []string {
-	azureVals := []string{
+func (t *ValidatorTest) azurePluginValues(ctx *test.TestContext, vals []string, sliceVals [][]string) ([]string, [][]string) {
+	azureVals := []any{
+		"y",                                    // enable RBAC validation
 		"rule-1",                               // rule name
 		"d551b7b1-78ae-43df-9d61-4935c843a454", // security principal
 		"Local Filepath",                       // Add permission sets via
 		t.filePath("azurePermissionSets.json"), // Permission sets file
 		"n",                                    // add RBAC rule
+
+		// new
+		"y",                                    // enable community gallery image validation
+		"rule-2",                               // rule name
+		"westus",                               // location
+		"testgallery",                          // gallery name
+		[]string{"a"},                          // images
+		"d551b7b1-78ae-43df-9d61-4935c843a454", // subscription
+		"n",                                    // add community gallery image rule
 	}
-	vals = append(vals, azureVals...)
-	return vals
+	return interleave(vals, sliceVals, azureVals)
 }
 
 func (t *ValidatorTest) networkPluginInstallValues(ctx *test.TestContext, vals []string) []string {


### PR DESCRIPTION
## Issue
Resolves #124

## Description
Adds prompts for the Azure community gallery image rule which lets users verify that a particular community image gallery exists within a particular subscription. If it exists, it is accessible by any security principal and Azure system because community image galleries are public.
    
Also refactors Azure plugin related code to be more like other plugins. Same structure for prompting and no more "RBAC rule type" which must be encoded in the config file and taken into account when re-configuring.


