### PR TITLE
fix: remove duplicate maas base values from template

### DIFF
--- a/pkg/utils/embed/resources/validator/validator-base-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-base-values.tmpl
@@ -203,13 +203,4 @@ pluginSecrets:
   {{- else }}
   vSphere: {}
   {{- end }}
-
-  {{- if .MAASPlugin.Validator.Auth.SecretName }}
-  maas:
-    secretName: {{ .MAASPlugin.Validator.Auth.SecretName }}
-    tokenKey: {{ .MAASPlugin.Validator.Auth.TokenKey }}
-    maasApiToken: {{ .MAASPlugin.MaasAPIToken }}
-  {{- else }}
-  maas: {}
-  {{- end }}
   


### PR DESCRIPTION
## Issue

## Description
MAAS auth was present 2 times in the base values template. Deleting the out-of-order template.