### PR TITLE
refactor: move vsphere account under auth to match new plugin api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/validator-labs/validator-plugin-maas v0.0.8-0.20240820005521-e903cc7f7fc4
 	github.com/validator-labs/validator-plugin-network v0.0.23
 	github.com/validator-labs/validator-plugin-oci v0.2.1
-	github.com/validator-labs/validator-plugin-vsphere v0.0.30
+	github.com/validator-labs/validator-plugin-vsphere v0.0.31
 	github.com/vmware/govmomi v0.42.0
 	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa
 	gopkg.in/ini.v1 v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -691,8 +691,8 @@ github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vv
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
-github.com/onsi/ginkgo/v2 v2.20.0 h1:PE84V2mHqoT1sglvHc8ZdQtPcwmvvt29WLEEO3xmdZw=
-github.com/onsi/ginkgo/v2 v2.20.0/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
+github.com/onsi/ginkgo/v2 v2.20.1 h1:YlVIbqct+ZmnEph770q9Q7NVAz4wwIiVNahee6JyUzo=
+github.com/onsi/ginkgo/v2 v2.20.1/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
@@ -874,8 +874,8 @@ github.com/validator-labs/validator-plugin-network v0.0.23 h1:+1fooiXuve73NAOUTT
 github.com/validator-labs/validator-plugin-network v0.0.23/go.mod h1:9f7tzIR1toQD0XVMTIba/42V+06j4IoUhwELe+V0Jfs=
 github.com/validator-labs/validator-plugin-oci v0.2.1 h1:FlT0zv5j7XrrRdPgxbJgy8U6mWrNYb0R4ZXs7zuiPKE=
 github.com/validator-labs/validator-plugin-oci v0.2.1/go.mod h1:G8oa+TXAiwul9ryFmnEcPZfCvdrt7TXPnQPXXNEnua8=
-github.com/validator-labs/validator-plugin-vsphere v0.0.30 h1:CgJUW8vEftslSAb/xmHZW5dtS51tEA/n6pmN+dwk9Ao=
-github.com/validator-labs/validator-plugin-vsphere v0.0.30/go.mod h1:g2+O2WYlXYYX5FxHfa7Vu7GCJLtX9QgQ0A8+9IODpQY=
+github.com/validator-labs/validator-plugin-vsphere v0.0.31 h1:pCb+gZ7EOK+AjLmcpMv4anWF35tTqgq6vtYEgL6gISI=
+github.com/validator-labs/validator-plugin-vsphere v0.0.31/go.mod h1:zqYtw16TtRD5Q6CrIXEwkPxEVsbhW5ImBgDavGZu1UI=
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/vmware/govmomi v0.42.0 h1:MbvAlVfjNBE1mHMaQ7yOSop1KLB0/93x6VAGuCtjqtI=

--- a/hack/validator.tmpl
+++ b/hack/validator.tmpl
@@ -234,14 +234,14 @@ vspherePlugin:
       repository: validator-plugin-vsphere
       version: v${VSPHERE_VERSION}
     values: ""
-  account:
-    insecure: true
-    password: vn0cCP3U08iqDUwwCgBFWBbfekA+4TTe
-    username: bob@vsphere.com
-    vcenterServer: fake.vsphere.com
   validator:
     auth:
       secretName: vsphere-creds
+      cloudAccount:
+        insecure: true
+        password: vn0cCP3U08iqDUwwCgBFWBbfekA+4TTe
+        username: bob@vsphere.com
+        vcenterServer: fake.vsphere.com
     datacenter: DC0
     entityPrivilegeValidationRules:
     - name: 'Read folder: spectro-templates'

--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -636,7 +636,7 @@ func executePlugins(c *cfg.Config, vc *components.ValidatorConfig) error {
 			Spec: *vc.VspherePlugin.Validator,
 		}
 		vr := vres.Build(v)
-		vrr := vsphereval.Validate(context.Background(), *vc.VspherePlugin.Validator, vc.VspherePlugin.Account, l)
+		vrr := vsphereval.Validate(context.Background(), *vc.VspherePlugin.Validator, vc.VspherePlugin.Validator.Auth.CloudAccount, l)
 		if err := vres.Finalize(vr, vrr, l); err != nil {
 			return err
 		}

--- a/pkg/components/validator.go
+++ b/pkg/components/validator.go
@@ -14,7 +14,6 @@ import (
 	network "github.com/validator-labs/validator-plugin-network/api/v1alpha1"
 	oci "github.com/validator-labs/validator-plugin-oci/api/v1alpha1"
 	vsphereapi "github.com/validator-labs/validator-plugin-vsphere/api/v1alpha1"
-	"github.com/validator-labs/validator-plugin-vsphere/pkg/vsphere"
 	validator "github.com/validator-labs/validator/api/v1alpha1"
 
 	cfg "github.com/validator-labs/validatorctl/pkg/config"
@@ -96,7 +95,6 @@ func NewValidatorConfig() *ValidatorConfig {
 		VspherePlugin: &VspherePluginConfig{
 			Release:   &validator.HelmRelease{},
 			Validator: &vsphereapi.VsphereValidatorSpec{},
-			Account:   &vsphere.CloudAccount{},
 		},
 	}
 }
@@ -559,7 +557,6 @@ func (c *OCIPluginConfig) decrypt() error {
 type VspherePluginConfig struct {
 	Enabled                     bool                             `yaml:"enabled"`
 	Release                     *validator.HelmRelease           `yaml:"helmRelease"`
-	Account                     *vsphere.CloudAccount            `yaml:"account"`
 	Validator                   *vsphereapi.VsphereValidatorSpec `yaml:"validator"`
 	VsphereEntityPrivilegeRules []VsphereEntityPrivilegeRule     `yaml:"vsphereEntityPrivilegeRules"`
 	VsphereRolePrivilegeRules   []VsphereRolePrivilegeRule       `yaml:"vsphereRolePrivilegeRules"`
@@ -567,23 +564,23 @@ type VspherePluginConfig struct {
 }
 
 func (c *VspherePluginConfig) encrypt() error {
-	if c.Account != nil {
-		password, err := crypto.EncryptB64([]byte(c.Account.Password))
+	if c.Validator.Auth.CloudAccount != nil {
+		password, err := crypto.EncryptB64([]byte(c.Validator.Auth.CloudAccount.Password))
 		if err != nil {
 			return errors.Wrap(err, "failed to encrypt password")
 		}
-		c.Account.Password = password
+		c.Validator.Auth.CloudAccount.Password = password
 	}
 	return nil
 }
 
 func (c *VspherePluginConfig) decrypt() error {
-	if c.Account != nil {
-		bytes, err := crypto.DecryptB64(c.Account.Password)
+	if c.Validator.Auth.CloudAccount != nil {
+		bytes, err := crypto.DecryptB64(c.Validator.Auth.CloudAccount.Password)
 		if err != nil {
 			return errors.Wrap(err, "failed to decrypt password")
 		}
-		c.Account.Password = string(*bytes)
+		c.Validator.Auth.CloudAccount.Password = string(*bytes)
 	}
 	return nil
 }

--- a/pkg/config/versions.go
+++ b/pkg/config/versions.go
@@ -2,11 +2,11 @@ package config
 
 // ValidatorChartVersions is a map of validator component names to their respective versions
 var ValidatorChartVersions = map[string]string{
-	Validator:              "v0.1.7",
-	ValidatorPluginAws:     "v0.1.4",
-	ValidatorPluginAzure:   "v0.0.17",
-	ValidatorPluginMaas:    "v0.0.7",
-	ValidatorPluginNetwork: "v0.0.23",
-	ValidatorPluginOci:     "v0.2.1",
-	ValidatorPluginVsphere: "v0.0.31",
+	Validator:              "v0.1.8",
+	ValidatorPluginAws:     "v0.1.6",
+	ValidatorPluginAzure:   "v0.0.19",
+	ValidatorPluginMaas:    "v0.0.8",
+	ValidatorPluginNetwork: "v0.0.25",
+	ValidatorPluginOci:     "v0.3.1",
+	ValidatorPluginVsphere: "v0.0.33",
 }

--- a/pkg/services/validator/vmware.go
+++ b/pkg/services/validator/vmware.go
@@ -67,7 +67,7 @@ func readVspherePluginRules(vc *components.ValidatorConfig, _ *cfg.TaskConfig, _
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	vSphereCloudDriver, err := clouds.GetVSphereDriver(c.Account)
+	vSphereCloudDriver, err := clouds.GetVSphereDriver(c.Validator.Auth.CloudAccount)
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func readVspherePluginRules(vc *components.ValidatorConfig, _ *cfg.TaskConfig, _
 
 func readVsphereCredentials(c *components.VspherePluginConfig, tc *cfg.TaskConfig, k8sClient kubernetes.Interface) error {
 	var err error
-
+	c.Validator.Auth.CloudAccount = &vsphere.CloudAccount{}
 	// always create vSphere credential secret if creating a new kind cluster
 	createSecret := true
 
@@ -133,7 +133,7 @@ func readVsphereCredentials(c *components.VspherePluginConfig, tc *cfg.TaskConfi
 				return err
 			}
 		}
-		if err := clouds.ReadVsphereAccountProps(c.Account); err != nil {
+		if err := clouds.ReadVsphereAccountProps(c.Validator.Auth.CloudAccount); err != nil {
 			return err
 		}
 	} else {
@@ -146,14 +146,14 @@ func readVsphereCredentials(c *components.VspherePluginConfig, tc *cfg.TaskConfi
 		if err != nil {
 			return err
 		}
-		c.Account.VcenterServer = string(secret.Data["vcenterServer"])
-		c.Account.Username = string(secret.Data["username"])
-		c.Account.Password = string(secret.Data["password"])
-		c.Account.Insecure = insecure
+		c.Validator.Auth.CloudAccount.VcenterServer = string(secret.Data["vcenterServer"])
+		c.Validator.Auth.CloudAccount.Username = string(secret.Data["username"])
+		c.Validator.Auth.CloudAccount.Password = string(secret.Data["password"])
+		c.Validator.Auth.CloudAccount.Insecure = insecure
 	}
 
 	// validate vSphere version
-	vSphereCloudDriver, err := clouds.GetVSphereDriver(c.Account)
+	vSphereCloudDriver, err := clouds.GetVSphereDriver(c.Validator.Auth.CloudAccount)
 	if err != nil {
 		return err
 	}
@@ -366,8 +366,8 @@ func readRolePrivilegeRule(c *components.VspherePluginConfig, r *components.Vsph
 			return err
 		}
 	} else {
-		log.InfoCLI(`Privilege validation rule will be applied for username %s`, c.Account.Username)
-		r.Username = c.Account.Username
+		log.InfoCLI(`Privilege validation rule will be applied for username %s`, c.Validator.Auth.CloudAccount.Username)
+		r.Username = c.Validator.Auth.CloudAccount.Username
 	}
 
 	if reconfigurePrivileges {
@@ -580,8 +580,8 @@ func readEntityPrivileges(ctx context.Context, c *components.VspherePluginConfig
 			return err
 		}
 	} else {
-		log.InfoCLI(`Privilege validation rule will be applied for username %s`, c.Account.Username)
-		r.Username = c.Account.Username
+		log.InfoCLI(`Privilege validation rule will be applied for username %s`, c.Validator.Auth.CloudAccount.Username)
+		r.Username = c.Validator.Auth.CloudAccount.Username
 	}
 
 	if reconfigureEntity {

--- a/pkg/services/validator/vmware_test.go
+++ b/pkg/services/validator/vmware_test.go
@@ -25,7 +25,6 @@ var vSphereDummyConfig = &components.ValidatorConfig{
 		Release: &v1alpha1.HelmRelease{
 			Chart: v1alpha1.HelmChart{},
 		},
-		Account:   &vsphere.CloudAccount{},
 		Validator: &vsphereapi.VsphereValidatorSpec{},
 	},
 	Release: &v1alpha1.HelmRelease{

--- a/pkg/utils/embed/resources/validator/validator-base-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-base-values.tmpl
@@ -194,20 +194,14 @@ pluginSecrets:
   {{- end }}
 
   {{- if .VspherePlugin.Enabled }}
-  {{- if .VspherePlugin.Validator.Auth.SecretName }}
   vSphere:
+    {{- if .VspherePlugin.Validator.Auth.SecretName }}
     secretName: {{ .VspherePlugin.Validator.Auth.SecretName }}
-    username: {{ .VspherePlugin.Validator.Auth.CloudAccount.Username | quote }}
-    password: {{ .VspherePlugin.Validator.Auth.CloudAccount.Password | quote }}
-    vcenterServer: {{ .VspherePlugin.Validator.Auth.CloudAccount.VcenterServer | quote }}
-    insecureSkipVerify: {{ .VspherePlugin.Validator.Auth.CloudAccount.Insecure | quote }}
-  {{- else }}
-  vSphere:
+    {{- end }}
     username: {{ .VspherePlugin.Validator.Auth.CloudAccount.Username | quote }}
     password: {{ .VspherePlugin.Validator.Auth.CloudAccount.Password | quote }}
     vcenterServer: {{ .VspherePlugin.Validator.Auth.CloudAccount.VcenterServer | quote }}
     insecureSkipVerify: {{ .VspherePlugin.Validator.Auth.CloudAccount.Insecure | quote }} 
-  {{- end }}
   {{- else }}
   vSphere: {}
   {{- end }}

--- a/pkg/utils/embed/resources/validator/validator-base-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-base-values.tmpl
@@ -193,13 +193,21 @@ pluginSecrets:
     {{- end }}
   {{- end }}
 
+  {{- if .VspherePlugin.Enabled }}
   {{- if .VspherePlugin.Validator.Auth.SecretName }}
   vSphere:
     secretName: {{ .VspherePlugin.Validator.Auth.SecretName }}
-    username: {{ .VspherePlugin.Account.Username | quote }}
-    password: {{ .VspherePlugin.Account.Password | quote }}
-    vcenterServer: {{ .VspherePlugin.Account.VcenterServer | quote }}
-    insecureSkipVerify: {{ .VspherePlugin.Account.Insecure | quote }}
+    username: {{ .VspherePlugin.Validator.Auth.CloudAccount.Username | quote }}
+    password: {{ .VspherePlugin.Validator.Auth.CloudAccount.Password | quote }}
+    vcenterServer: {{ .VspherePlugin.Validator.Auth.CloudAccount.VcenterServer | quote }}
+    insecureSkipVerify: {{ .VspherePlugin.Validator.Auth.CloudAccount.Insecure | quote }}
+  {{- else }}
+  vSphere:
+    username: {{ .VspherePlugin.Validator.Auth.CloudAccount.Username | quote }}
+    password: {{ .VspherePlugin.Validator.Auth.CloudAccount.Password | quote }}
+    vcenterServer: {{ .VspherePlugin.Validator.Auth.CloudAccount.VcenterServer | quote }}
+    insecureSkipVerify: {{ .VspherePlugin.Validator.Auth.CloudAccount.Insecure | quote }} 
+  {{- end }}
   {{- else }}
   vSphere: {}
   {{- end }}

--- a/tests/integration/_validator/testcases/data/validator.yaml
+++ b/tests/integration/_validator/testcases/data/validator.yaml
@@ -234,14 +234,14 @@ vspherePlugin:
       repository: validator-plugin-vsphere
       version: v0.0.31
     values: ""
-  account:
-    insecure: true
-    password: vn0cCP3U08iqDUwwCgBFWBbfekA+4TTe
-    username: bob@vsphere.com
-    vcenterServer: fake.vsphere.com
   validator:
     auth:
       secretName: vsphere-creds
+      cloudAccount:
+        insecure: true
+        password: vn0cCP3U08iqDUwwCgBFWBbfekA+4TTe
+        username: bob@vsphere.com
+        vcenterServer: fake.vsphere.com
     datacenter: DC0
     entityPrivilegeValidationRules:
     - name: 'Read folder: spectro-templates'

--- a/tests/integration/_validator/testcases/data/validator.yaml
+++ b/tests/integration/_validator/testcases/data/validator.yaml
@@ -5,7 +5,7 @@ helmRelease:
   chart:
     name: validator
     repository: validator
-    version: v0.1.7
+    version: v0.1.8
   values: ""
 helmReleaseSecret:
   name: validator-helm-release-validator
@@ -59,7 +59,7 @@ awsPlugin:
     chart:
       name: validator-plugin-aws
       repository: validator-plugin-aws
-      version: v0.1.4
+      version: v0.1.6
     values: ""
   accessKeyId: a0XCQd+Emx7/bwAaTyY13ipTRychb4MiQw==
   secretAccessKey: IrGIW8FPVuOxVDRWQUdTa22SDf1MQ2PBw0kdngVq+w==
@@ -173,7 +173,7 @@ networkPlugin:
     chart:
       name: validator-plugin-network
       repository: validator-plugin-network
-      version: v0.0.23
+      version: v0.0.25
     values: ""
   validator:
     dnsRules:
@@ -201,7 +201,7 @@ ociPlugin:
     chart:
       name: validator-plugin-oci
       repository: validator-plugin-oci
-      version: v0.2.1
+      version: v0.3.1
     values: ""
   secrets:
   - name: oci-creds
@@ -232,7 +232,7 @@ vspherePlugin:
     chart:
       name: validator-plugin-vsphere
       repository: validator-plugin-vsphere
-      version: v0.0.31
+      version: v0.0.33
     values: ""
   validator:
     auth:
@@ -525,7 +525,7 @@ azurePlugin:
     chart:
       name: validator-plugin-azure
       repository: validator-plugin-azure
-      version: v0.0.17
+      version: v0.0.19
       insecureSkipVerify: true
     values: ""
   tenantId: d551b7b1-78ae-43df-9d61-4935c843a454
@@ -832,7 +832,7 @@ maasPlugin:
     chart:
       name: validator-plugin-maas
       repository: validator-plugin-maas
-      version: v0.0.7
+      version: v0.0.8
     values: ""
   validator:
     internalDNSRules:


### PR DESCRIPTION
## Issue
Resolves #183 

## Description
Removing `VspherePluginConfig.Account` and switching to using `.Auth.CloudAccount`, to align with updates to the plugin.