### PR TITLE
fix: support `validator rules check -f config.yaml` without all plugins defined

### DIFF
--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -515,6 +515,7 @@ func configurePlugins(c *cfg.Config, vc *components.ValidatorConfig, tc *cfg.Tas
 	return nil
 }
 
+// nolint:gocyclo
 func executePlugins(c *cfg.Config, vc *components.ValidatorConfig) error {
 	log.Header("Executing validator plugin(s)")
 
@@ -525,7 +526,7 @@ func executePlugins(c *cfg.Config, vc *components.ValidatorConfig) error {
 	ok := true
 	results := make([]*vapi.ValidationResult, 0)
 
-	if vc.AWSPlugin.Enabled {
+	if vc.AWSPlugin != nil && vc.AWSPlugin.Enabled {
 		v := &awsapi.AwsValidator{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "aws-validator",
@@ -544,7 +545,7 @@ func executePlugins(c *cfg.Config, vc *components.ValidatorConfig) error {
 		results = append(results, vr)
 	}
 
-	if vc.AzurePlugin.Enabled {
+	if vc.AzurePlugin != nil && vc.AzurePlugin.Enabled {
 		v := &azureapi.AzureValidator{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "azure-validator",
@@ -563,7 +564,7 @@ func executePlugins(c *cfg.Config, vc *components.ValidatorConfig) error {
 		results = append(results, vr)
 	}
 
-	if vc.MaasPlugin.Enabled {
+	if vc.MaasPlugin != nil && vc.MaasPlugin.Enabled {
 		v := &maasapi.MaasValidator{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "maas-validator",
@@ -582,7 +583,7 @@ func executePlugins(c *cfg.Config, vc *components.ValidatorConfig) error {
 		results = append(results, vr)
 	}
 
-	if vc.NetworkPlugin.Enabled {
+	if vc.NetworkPlugin != nil && vc.NetworkPlugin.Enabled {
 		v := &netapi.NetworkValidator{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "network-validator",
@@ -604,7 +605,7 @@ func executePlugins(c *cfg.Config, vc *components.ValidatorConfig) error {
 		results = append(results, vr)
 	}
 
-	if vc.OCIPlugin.Enabled {
+	if vc.OCIPlugin != nil && vc.OCIPlugin.Enabled {
 		v := &ociapi.OciValidator{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "oci-validator",
@@ -626,7 +627,7 @@ func executePlugins(c *cfg.Config, vc *components.ValidatorConfig) error {
 		results = append(results, vr)
 	}
 
-	if vc.VspherePlugin.Enabled {
+	if vc.VspherePlugin != nil && vc.VspherePlugin.Enabled {
 		v := &vsphereapi.VsphereValidator{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "vsphere-validator",

--- a/pkg/components/validator.go
+++ b/pkg/components/validator.go
@@ -110,25 +110,22 @@ func (c *ValidatorConfig) AnyPluginEnabled() bool {
 func (c *ValidatorConfig) EnabledPluginsHaveRules() (bool, []string) {
 	var ok bool
 	invalidPlugins := []string{}
-	if c.AWSPlugin.Enabled && c.AWSPlugin.Validator.ResultCount() == 0 {
+	if c.AWSPlugin != nil && c.AWSPlugin.Enabled && c.AWSPlugin.Validator.ResultCount() == 0 {
 		invalidPlugins = append(invalidPlugins, c.AWSPlugin.Validator.PluginCode())
 	}
-	if c.AzurePlugin.Enabled && c.AzurePlugin.Validator.ResultCount() == 0 {
+	if c.AzurePlugin != nil && c.AzurePlugin.Enabled && c.AzurePlugin.Validator.ResultCount() == 0 {
 		invalidPlugins = append(invalidPlugins, c.AzurePlugin.Validator.PluginCode())
 	}
-	if c.MaasPlugin.Enabled && c.MaasPlugin.Validator.ResultCount() == 0 {
+	if c.MaasPlugin != nil && c.MaasPlugin.Enabled && c.MaasPlugin.Validator.ResultCount() == 0 {
 		invalidPlugins = append(invalidPlugins, c.MaasPlugin.Validator.PluginCode())
 	}
-	if c.MaasPlugin.Enabled && c.MaasPlugin.Validator.ResultCount() == 0 {
-		invalidPlugins = append(invalidPlugins, c.MaasPlugin.Validator.PluginCode())
-	}
-	if c.NetworkPlugin.Enabled && c.NetworkPlugin.Validator.ResultCount() == 0 {
+	if c.NetworkPlugin != nil && c.NetworkPlugin.Enabled && c.NetworkPlugin.Validator.ResultCount() == 0 {
 		invalidPlugins = append(invalidPlugins, c.NetworkPlugin.Validator.PluginCode())
 	}
-	if c.OCIPlugin.Enabled && c.OCIPlugin.Validator.ResultCount() == 0 {
+	if c.OCIPlugin != nil && c.OCIPlugin.Enabled && c.OCIPlugin.Validator.ResultCount() == 0 {
 		invalidPlugins = append(invalidPlugins, c.OCIPlugin.Validator.PluginCode())
 	}
-	if c.VspherePlugin.Enabled && c.VspherePlugin.Validator.ResultCount() == 0 {
+	if c.VspherePlugin != nil && c.VspherePlugin.Enabled && c.VspherePlugin.Validator.ResultCount() == 0 {
 		invalidPlugins = append(invalidPlugins, c.VspherePlugin.Validator.PluginCode())
 	}
 	if len(invalidPlugins) == 0 {

--- a/pkg/config/versions.go
+++ b/pkg/config/versions.go
@@ -2,11 +2,11 @@ package config
 
 // ValidatorChartVersions is a map of validator component names to their respective versions
 var ValidatorChartVersions = map[string]string{
-	Validator:              "v0.1.6",
+	Validator:              "v0.1.7",
 	ValidatorPluginAws:     "v0.1.4",
 	ValidatorPluginAzure:   "v0.0.17",
 	ValidatorPluginMaas:    "v0.0.7",
 	ValidatorPluginNetwork: "v0.0.23",
 	ValidatorPluginOci:     "v0.2.1",
-	ValidatorPluginVsphere: "v0.0.30",
+	ValidatorPluginVsphere: "v0.0.31",
 }

--- a/tests/integration/_validator/testcases/data/validator.yaml
+++ b/tests/integration/_validator/testcases/data/validator.yaml
@@ -5,7 +5,7 @@ helmRelease:
   chart:
     name: validator
     repository: validator
-    version: v0.1.6
+    version: v0.1.7
   values: ""
 helmReleaseSecret:
   name: validator-helm-release-validator
@@ -232,7 +232,7 @@ vspherePlugin:
     chart:
       name: validator-plugin-vsphere
       repository: validator-plugin-vsphere
-      version: v0.0.30
+      version: v0.0.31
     values: ""
   account:
     insecure: true


### PR DESCRIPTION
## Issue
Resolves https://github.com/validator-labs/validatorctl/issues/188

## Description
Ensures we dont panic when executing `validator rules check -f config.yaml` without all plugins defined
