### PR TITLE
fix: filter vCenter local file privileges properly, skip KUBECONFIG check when updating passwords in direct mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/pterm/pterm v0.12.79
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spectrocloud-labs/embeddedfs v0.1.0
-	github.com/spectrocloud-labs/prompts-tui v0.1.1
+	github.com/spectrocloud-labs/prompts-tui v0.1.2
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	github.com/validator-labs/validator v0.1.8

--- a/go.sum
+++ b/go.sum
@@ -807,8 +807,8 @@ github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9yS
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spectrocloud-labs/embeddedfs v0.1.0 h1:Izs9wPYLVp8Fp9mi9zYysu9AzvHK1kIelQz3IIfh4N0=
 github.com/spectrocloud-labs/embeddedfs v0.1.0/go.mod h1:JrCbGXImUCsim3jjYSahRJUKyVN57Fb5u3DkE3crqA4=
-github.com/spectrocloud-labs/prompts-tui v0.1.1 h1:jNYFt6UzrSEc8K6GXyRenH1jzKbHwJbCCGMYtYYXKUo=
-github.com/spectrocloud-labs/prompts-tui v0.1.1/go.mod h1:XCvyEc3OLxKVXNLbOGZJOR6PiktfWqjYdrwU+ymCmLQ=
+github.com/spectrocloud-labs/prompts-tui v0.1.2 h1:l9Bf1XdR4rHIJ+9evfBoTLThk+W2u3V2MfWYdZGwYMc=
+github.com/spectrocloud-labs/prompts-tui v0.1.2/go.mod h1:XCvyEc3OLxKVXNLbOGZJOR6PiktfWqjYdrwU+ymCmLQ=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=

--- a/pkg/config/versions.go
+++ b/pkg/config/versions.go
@@ -7,6 +7,6 @@ var ValidatorChartVersions = map[string]string{
 	ValidatorPluginAzure:   "v0.0.20",
 	ValidatorPluginMaas:    "v0.0.12",
 	ValidatorPluginNetwork: "v0.0.26",
-	ValidatorPluginOci:     "v0.3.2",
+	ValidatorPluginOci:     "v0.3.3",
 	ValidatorPluginVsphere: "v0.0.34",
 }

--- a/pkg/services/validator/validator_service.go
+++ b/pkg/services/validator/validator_service.go
@@ -474,22 +474,27 @@ func UpdateValidatorCredentials(c *components.ValidatorConfig) error {
 
 // UpdateValidatorPluginCredentials updates validator plugin credentials
 func UpdateValidatorPluginCredentials(c *components.ValidatorConfig, tc *cfg.TaskConfig) error {
-	k8sClient, err := k8sClientFromConfig(c)
-	if err != nil {
-		return err
+	var err error
+	var kClient kubernetes.Interface
+
+	if !tc.Direct {
+		kClient, err = k8sClientFromConfig(c)
+		if err != nil {
+			return err
+		}
 	}
 	if c.AWSPlugin != nil && c.AWSPlugin.Enabled {
-		if err := readAwsCredentials(c.AWSPlugin, tc, k8sClient); err != nil {
+		if err := readAwsCredentials(c.AWSPlugin, tc, kClient); err != nil {
 			return fmt.Errorf("failed to update AWS credentials: %w", err)
 		}
 	}
 	if c.AzurePlugin != nil && c.AzurePlugin.Enabled {
-		if err := readAzureCredentials(c.AzurePlugin, tc, k8sClient); err != nil {
+		if err := readAzureCredentials(c.AzurePlugin, tc, kClient); err != nil {
 			return fmt.Errorf("failed to update Azure credentials: %w", err)
 		}
 	}
 	if c.MaasPlugin != nil && c.MaasPlugin.Enabled {
-		if err := readMaasCredentials(c.MaasPlugin, tc, k8sClient); err != nil {
+		if err := readMaasCredentials(c.MaasPlugin, tc, kClient); err != nil {
 			return fmt.Errorf("failed to update MAAS credentials: %w", err)
 		}
 	}
@@ -501,7 +506,7 @@ func UpdateValidatorPluginCredentials(c *components.ValidatorConfig, tc *cfg.Tas
 		}
 	}
 	if c.VspherePlugin != nil && c.VspherePlugin.Enabled {
-		if err := readVsphereCredentials(c.VspherePlugin, tc, k8sClient); err != nil {
+		if err := readVsphereCredentials(c.VspherePlugin, tc, kClient); err != nil {
 			return fmt.Errorf("failed to update vSphere credentials: %w", err)
 		}
 	}

--- a/tests/integration/_validator/testcases/data/validator.yaml
+++ b/tests/integration/_validator/testcases/data/validator.yaml
@@ -201,7 +201,7 @@ ociPlugin:
     chart:
       name: validator-plugin-oci
       repository: validator-plugin-oci
-      version: v0.3.2
+      version: v0.3.3
     values: ""
   secrets:
   - name: oci-creds


### PR DESCRIPTION
## Issue
N/A

## Description
- Filter empty lines and comments from vCenter local file privileges
- Skip `KUBECONFIG` check when updating passwords in direct mode
