### PR TITLE
feat: add --custom-resources flag to validator rules check as an alternate to -f

### DIFF
--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -209,11 +209,16 @@ For more information about validator, see: https://github.com/validator-labs/val
 
 	flags := cmd.Flags()
 	flags.StringVarP(&tc.ConfigFile, "config-file", "f", "", "Validator configuration file.")
+	flags.StringVar(&tc.CRPath, "cr", "", "Path to a file or directory containing validator custom resource yaml documents.")
 	flags.BoolVarP(&tc.CreateConfigOnly, "config-only", "o", false, "Update configuration file only. Do not proceed with checks. Default: false.")
 	flags.BoolVarP(&tc.UpdatePasswords, "update-passwords", "p", false, "Update passwords only. Do not proceed with checks. Default: false.")
 	flags.BoolVarP(&tc.Reconfigure, "reconfigure", "r", false, "Re-configure plugin rules prior to running checks. Default: false.")
 
 	cmd.MarkFlagsMutuallyExclusive("update-passwords", "reconfigure")
+	cmd.MarkFlagsMutuallyExclusive("config-file", "cr")
+	cmd.MarkFlagsMutuallyExclusive("config-only", "cr")
+	cmd.MarkFlagsMutuallyExclusive("update-passwords", "cr")
+	cmd.MarkFlagsMutuallyExclusive("reconfigure", "cr")
 
 	return cmd
 }

--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -209,7 +209,7 @@ For more information about validator, see: https://github.com/validator-labs/val
 
 	flags := cmd.Flags()
 	flags.StringVarP(&tc.ConfigFile, "config-file", "f", "", "Validator configuration file.")
-	flags.StringVar(&tc.CRPath, "cr", "", "Path to a file or directory containing validator custom resource yaml documents.")
+	flags.StringVar(&tc.CRPath, "cr", "", "Path to a file or directory containing validator custom resource YAML documents.")
 	flags.BoolVarP(&tc.CreateConfigOnly, "config-only", "o", false, "Update configuration file only. Do not proceed with checks. Default: false.")
 	flags.BoolVarP(&tc.UpdatePasswords, "update-passwords", "p", false, "Update passwords only. Do not proceed with checks. Default: false.")
 	flags.BoolVarP(&tc.Reconfigure, "reconfigure", "r", false, "Re-configure plugin rules prior to running checks. Default: false.")

--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -209,16 +209,16 @@ For more information about validator, see: https://github.com/validator-labs/val
 
 	flags := cmd.Flags()
 	flags.StringVarP(&tc.ConfigFile, "config-file", "f", "", "Validator configuration file.")
-	flags.StringVar(&tc.CRPath, "cr", "", "Path to a file or directory containing validator custom resource YAML documents.")
+	flags.StringVar(&tc.CustomResources, "custom-resources", "", "Path to a file or directory containing validator custom resource YAML documents.")
 	flags.BoolVarP(&tc.CreateConfigOnly, "config-only", "o", false, "Update configuration file only. Do not proceed with checks. Default: false.")
 	flags.BoolVarP(&tc.UpdatePasswords, "update-passwords", "p", false, "Update passwords only. Do not proceed with checks. Default: false.")
 	flags.BoolVarP(&tc.Reconfigure, "reconfigure", "r", false, "Re-configure plugin rules prior to running checks. Default: false.")
 
 	cmd.MarkFlagsMutuallyExclusive("update-passwords", "reconfigure")
-	cmd.MarkFlagsMutuallyExclusive("config-file", "cr")
-	cmd.MarkFlagsMutuallyExclusive("config-only", "cr")
-	cmd.MarkFlagsMutuallyExclusive("update-passwords", "cr")
-	cmd.MarkFlagsMutuallyExclusive("reconfigure", "cr")
+	cmd.MarkFlagsMutuallyExclusive("config-file", "custom-resources")
+	cmd.MarkFlagsMutuallyExclusive("config-only", "custom-resources")
+	cmd.MarkFlagsMutuallyExclusive("update-passwords", "custom-resources")
+	cmd.MarkFlagsMutuallyExclusive("reconfigure", "custom-resources")
 
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spectrocloud-labs/prompts-tui v0.1.2
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
+	github.com/stretchr/testify v1.9.0
 	github.com/validator-labs/validator v0.1.10
 	github.com/validator-labs/validator-plugin-aws v0.1.7
 	github.com/validator-labs/validator-plugin-azure v0.0.20
@@ -201,6 +202,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect

--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -203,14 +203,14 @@ func ConfigureOrCheckCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 	var err error
 	var saveConfig bool
 
-	if tc.CRPath != "" && tc.Direct {
-		pluginSpecs, err := readPluginSpecs(tc.CRPath)
+	if tc.CustomResources != "" && tc.Direct {
+		pluginSpecs, err := readPluginSpecs(tc.CustomResources)
 		if err != nil {
 			return err
 		}
 
 		if len(pluginSpecs) == 0 {
-			log.InfoCLI("No plugin rule CRs found in %s", tc.CRPath)
+			log.InfoCLI("No plugin rule custom resources found in %s", tc.CustomResources)
 			return nil
 		}
 

--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -198,6 +198,20 @@ func ConfigureOrCheckCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 	var err error
 	var saveConfig bool
 
+	if tc.CRPath != "" && tc.Direct {
+		pluginSpecs, err := readPluginSpecs(tc.CRPath)
+		if err != nil {
+			return err
+		}
+
+		if len(pluginSpecs) == 0 {
+			log.InfoCLI("No plugin rule CRs found in %s", tc.CRPath)
+			return nil
+		}
+
+		return executePlugins(c, pluginSpecs, nil)
+	}
+
 	if !tc.Reconfigure {
 		// Silent Mode
 		vc, err = components.NewValidatorFromConfig(tc)
@@ -249,7 +263,7 @@ func ConfigureOrCheckCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 	}
 
 	if tc.Direct {
-		return executePlugins(c, pluginSpecs(vc), vc.SinkConfig)
+		return executePlugins(c, toPluginSpecs(vc), vc.SinkConfig)
 	}
 
 	// upgrade the validator helm release so that plugin rule secrets
@@ -268,7 +282,17 @@ func ConfigureOrCheckCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 	return nil
 }
 
-func pluginSpecs(vc *components.ValidatorConfig) []plugins.PluginSpec {
+func readPluginSpecs(path string) ([]plugins.PluginSpec, error) {
+	log.InfoCLI("Reading plugin specs from %s", path)
+
+	// TODO:
+	// get a list of files to check. if its a directory the list is all the files in the dir, if its a file the list is the single file
+	// read all files in this list and return all the plugin specs in each of the files
+	// return the list of plugin specs
+	return []plugins.PluginSpec{}, nil
+}
+
+func toPluginSpecs(vc *components.ValidatorConfig) []plugins.PluginSpec {
 	pluginSpecs := make([]plugins.PluginSpec, 0)
 	if vc.AWSPlugin != nil && vc.AWSPlugin.Enabled {
 		pluginSpecs = append(pluginSpecs, vc.AWSPlugin.Validator)

--- a/pkg/cmd/validator/validator_test.go
+++ b/pkg/cmd/validator/validator_test.go
@@ -2,7 +2,6 @@ package validator
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/cmd/validator/validator_test.go
+++ b/pkg/cmd/validator/validator_test.go
@@ -1,12 +1,17 @@
 package validator
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	netapi "github.com/validator-labs/validator-plugin-network/api/v1alpha1"
 	vapi "github.com/validator-labs/validator/api/v1alpha1"
+	"github.com/validator-labs/validator/pkg/plugins"
 )
 
 func TestBuildValidationResultString(t *testing.T) {
@@ -109,6 +114,73 @@ Failures
 
 			if vrStr != tc.expectedVrStr {
 				t.Errorf("\nexpected vrStr:\n%s\nactual vrStr:\n%s", tc.expectedVrStr, vrStr)
+			}
+		})
+	}
+}
+
+func TestUnmarshalPluginSpec(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        []byte
+		expectedSpec plugins.PluginSpec
+		expectedErr  error
+	}{
+		{
+			name: "Valid NetworkValidator spec",
+			input: []byte(
+				`apiVersion: validation.spectrocloud.labs/v1alpha1
+kind: NetworkValidator
+metadata:
+  name: network-validator-combined-network-rules
+spec:
+  dnsRules:
+  - name: Resolve Google
+    host: google.com
+`),
+			expectedSpec: &netapi.NetworkValidatorSpec{
+				DNSRules: []netapi.DNSRule{
+					{RuleName: "Resolve Google", Host: "google.com"},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:         "Unknown plugin kind",
+			input:        []byte(`kind: SomeRandomKind`),
+			expectedSpec: nil,
+			expectedErr:  errors.New("unknown plugin kind"),
+		},
+		{
+			name: "Kind not set",
+			input: []byte(
+				`spec:
+  dnsRules:
+  - name: Resolve Google
+    host: google.com
+`),
+			expectedSpec: nil,
+			expectedErr:  errors.New("plugin kind is not set"),
+		},
+		{
+			name:         "Invalid YAML format",
+			input:        []byte("hello"),
+			expectedSpec: nil,
+			expectedErr:  errors.New("cannot unmarshal"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, err := unmarshalPluginSpec(tt.input)
+
+			// If an error is expected
+			if tt.expectedErr != nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedSpec, spec)
 			}
 		})
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,7 @@ type Config struct {
 type TaskConfig struct {
 	CliVersion       string
 	ConfigFile       string
-	CRPath           string
+	CustomResources  string
 	Apply            bool
 	CreateConfigOnly bool
 	DeleteCluster    bool

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 type TaskConfig struct {
 	CliVersion       string
 	ConfigFile       string
+	CRPath           string
 	Apply            bool
 	CreateConfigOnly bool
 	DeleteCluster    bool

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -36,6 +36,13 @@ const (
 	ValidatorPluginOci     = "validator-plugin-oci"
 	ValidatorPluginVsphere = "validator-plugin-vsphere"
 
+	ValidatorPluginAwsKind     = "AwsValidator"
+	ValidatorPluginAzureKind   = "AzureValidator"
+	ValidatorPluginMaasKind    = "MaasValidator"
+	ValidatorPluginNetworkKind = "NetworkValidator"
+	ValidatorPluginOciKind     = "OciValidator"
+	ValidatorPluginVsphereKind = "VsphereValidator"
+
 	ValidatorPluginAwsTemplate     = "validator-rules-aws.tmpl"
 	ValidatorPluginAzureTemplate   = "validator-rules-azure.tmpl"
 	ValidatorPluginMaasTemplate    = "validator-rules-maas.tmpl"

--- a/pkg/config/versions.go
+++ b/pkg/config/versions.go
@@ -2,7 +2,7 @@ package config
 
 // ValidatorChartVersions is a map of validator component names to their respective versions
 var ValidatorChartVersions = map[string]string{
-	Validator:              "v0.1.10",
+	Validator:              "v0.1.11",
 	ValidatorPluginAws:     "v0.1.7",
 	ValidatorPluginAzure:   "v0.0.20",
 	ValidatorPluginMaas:    "v0.0.12",

--- a/pkg/utils/file/file.go
+++ b/pkg/utils/file/file.go
@@ -1,0 +1,28 @@
+// Package file provides utility functions for working with a filesystem.
+package file
+
+import (
+	"io/fs"
+	"path/filepath"
+)
+
+// GetFilesInDir walks the file tree from dir and returns a list of all files found in lexical order.
+func GetFilesInDir(dir string) ([]string, error) {
+	files := make([]string, 0)
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() {
+			files = append(files, path)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}

--- a/pkg/utils/file/file_test.go
+++ b/pkg/utils/file/file_test.go
@@ -1,0 +1,101 @@
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var content = []byte("test content")
+
+func cleanup(dir string) error {
+	return os.RemoveAll(dir)
+}
+
+func TestGetFilesInDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func() (string, error)
+		expected []string
+	}{
+		{
+			name: "empty directory",
+			setup: func() (string, error) {
+				dir, err := os.MkdirTemp("", "test-empty-dir")
+				return dir, err
+			},
+			expected: []string{},
+		},
+		{
+			name: "directory with files",
+			setup: func() (string, error) {
+				dir, err := os.MkdirTemp("", "test-dir-with-files")
+				if err != nil {
+					return "", err
+				}
+
+				files := []string{"file1.txt", "file2.txt"}
+				for _, file := range files {
+					err = os.WriteFile(filepath.Join(dir, file), content, 0644)
+					if err != nil {
+						return "", err
+					}
+				}
+				return dir, nil
+			},
+			expected: []string{"file1.txt", "file2.txt"},
+		},
+		{
+			name: "nested directories with files",
+			setup: func() (string, error) {
+				dir, err := os.MkdirTemp("", "test-nested-dir")
+				if err != nil {
+					return "", err
+				}
+
+				subDir := filepath.Join(dir, "subdir")
+				err = os.Mkdir(subDir, 0755)
+				if err != nil {
+					return "", err
+				}
+				err = os.WriteFile(filepath.Join(dir, "file1.txt"), content, 0644)
+				if err != nil {
+					return "", err
+				}
+				err = os.WriteFile(filepath.Join(subDir, "file2.txt"), content, 0644)
+				if err != nil {
+					return "", err
+				}
+				err = os.WriteFile(filepath.Join(subDir, "file3.txt"), content, 0644)
+				if err != nil {
+					return "", err
+				}
+				return dir, nil
+			},
+			expected: []string{"file1.txt", "subdir/file2.txt", "subdir/file3.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup test directory and files
+			dir, err := tt.setup()
+			if err != nil {
+				t.Fatalf("Setup failed: %v", err)
+			}
+			defer cleanup(dir)
+
+			files, err := GetFilesInDir(dir)
+			if err != nil {
+				t.Fatalf("GetFilesInDir() error = %v", err)
+			}
+
+			// Validate the result
+			for i, file := range files {
+				if file != filepath.Join(dir, tt.expected[i]) {
+					t.Errorf("Expected file %v, got %v", tt.expected[i], file)
+				}
+			}
+		})
+	}
+}

--- a/tests/integration/_validator/testcases/data/validator-crs/combined.yaml
+++ b/tests/integration/_validator/testcases/data/validator-crs/combined.yaml
@@ -1,0 +1,20 @@
+apiVersion: validation.spectrocloud.labs/v1alpha1
+kind: OciValidator
+metadata:
+  name: oci-validator-combined-oci-rules
+spec:
+  ociRegistryRules:
+    - name: "public oci registry with tag"
+      host: "docker.io"
+      validationType: "none"
+      artifacts:
+        - ref: "library/redis:7.2.4"
+---
+apiVersion: validation.spectrocloud.labs/v1alpha1
+kind: NetworkValidator
+metadata:
+  name: network-validator-combined-network-rules
+spec:
+  dnsRules:
+  - name: Resolve Google
+    host: google.com

--- a/tests/integration/_validator/testcases/data/validator-crs/network/network.yaml
+++ b/tests/integration/_validator/testcases/data/validator-crs/network/network.yaml
@@ -1,0 +1,8 @@
+apiVersion: validation.spectrocloud.labs/v1alpha1
+kind: NetworkValidator
+metadata:
+  name: network-validator-network-rules
+spec:
+  dnsRules:
+  - name: Resolve Amazon
+    host: amazon.com

--- a/tests/integration/_validator/testcases/data/validator-crs/oci/oci.yaml
+++ b/tests/integration/_validator/testcases/data/validator-crs/oci/oci.yaml
@@ -1,0 +1,11 @@
+apiVersion: validation.spectrocloud.labs/v1alpha1
+kind: OciValidator
+metadata:
+  name: oci-validator-oci-rules
+spec:
+  ociRegistryRules:
+    - name: "public oci registry with default latest tag"
+      host: "registry.hub.docker.com"
+      validationType: "fast"
+      artifacts:
+        - ref: "ahmadibraspectrocloud/kubebuilder-cron"

--- a/tests/integration/_validator/testcases/data/validator.yaml
+++ b/tests/integration/_validator/testcases/data/validator.yaml
@@ -5,7 +5,7 @@ helmRelease:
   chart:
     name: validator
     repository: validator
-    version: v0.1.10
+    version: v0.1.11
   values: ""
 helmReleaseSecret:
   name: validator-helm-release-validator

--- a/tests/integration/_validator/testcases/test_validator.go
+++ b/tests/integration/_validator/testcases/test_validator.go
@@ -621,7 +621,7 @@ func (t *ValidatorTest) testRulesCheckCustomResource() (tr *test.TestResult) {
 	t.log.Printf("Executing testRulesCheckCustomResource")
 
 	checkCmd, buffer := common.InitCmd([]string{
-		"rules", "check", "-l", "debug", "--cr", t.filePath("validator-crs"),
+		"rules", "check", "-l", "debug", "--custom-resources", t.filePath("validator-crs"),
 	})
 	return common.ExecCLI(checkCmd, buffer, t.log, true)
 }

--- a/tests/integration/_validator/testcases/test_validator.go
+++ b/tests/integration/_validator/testcases/test_validator.go
@@ -62,6 +62,9 @@ func (t *ValidatorTest) Execute(ctx *test.TestContext) (tr *test.TestResult) {
 	if result := t.testRulesCheck(); result.IsFailed() {
 		return result
 	}
+	if result := t.testRulesCheckCustomResource(); result.IsFailed() {
+		return result
+	}
 	if result := t.testDescribe(); result.IsFailed() {
 		return result
 	}
@@ -610,6 +613,15 @@ func (t *ValidatorTest) testRulesCheck() (tr *test.TestResult) {
 
 	checkCmd, buffer := common.InitCmd([]string{
 		"rules", "check", "-l", "debug", "-f", t.filePath(cfg.ValidatorConfigFile),
+	})
+	return common.ExecCLI(checkCmd, buffer, t.log, true)
+}
+
+func (t *ValidatorTest) testRulesCheckCustomResource() (tr *test.TestResult) {
+	t.log.Printf("Executing testRulesCheckCustomResource")
+
+	checkCmd, buffer := common.InitCmd([]string{
+		"rules", "check", "-l", "debug", "--cr", t.filePath("validator-crs"),
 	})
 	return common.ExecCLI(checkCmd, buffer, t.log, true)
 }


### PR DESCRIPTION
## Issue
Resolves https://github.com/validator-labs/validatorctl/issues/178
Resolves https://github.com/validator-labs/validatorctl/issues/136

## Description
This PR adds support for passing in custom resource documents to the `validator rules check` command via the `--custom-resources` flag. The `--custom-resources` flag can receive either a path to a directory or to a file. 

### File selection
If a directory path is provided, we check each file within the directory for CR documents. Note that we walk the entire file tree from a particular directory. This means that users are able to organize their CRs in a manner like this:
```
❯ tree tests/integration/_validator/testcases/data/validator-crs
tests/integration/_validator/testcases/data/validator-crs
├── combined.yaml
├── network
│   └── network.yaml
└── oci
    └── oci.yaml

3 directories, 3 files
```
In the above example, we'll look for CRs within the slice of all 3 files found (combined.yaml, network.yaml, and oci.yaml). Users have the flexibility to organize their CRs as they desire.

If a single file is instead passed in via the `--cr` flag, we only work with a slice containing the single file that was provided.

### CR Unmarshalling
Given a slice of files (which may only contain a single file), we range over each file and attempt the following:

We try to read all the CR documents that are contained in that file and run validations against them.

For instance, if the path to the following file is passed in:
```
apiVersion: validation.spectrocloud.labs/v1alpha1
kind: OciValidator
metadata:
  name: oci-validator-combined-oci-rules
spec:
  ociRegistryRules:
    - name: "public oci registry with tag"
      host: "docker.io"
      validationType: "none"
      artifacts:
        - ref: "library/redis:7.2.4"
---
apiVersion: validation.spectrocloud.labs/v1alpha1
kind: NetworkValidator
metadata:
  name: network-validator-combined-network-rules
spec:
  dnsRules:
  - name: Resolve Google
    host: google.com
```

We'll run validations against both he network and the oci plugin rules that are defined in the file. Users can choose to store all CRs in a single file, or spread them across multiple files. Whatever configuration they choose will work.

### Error handling
Succesfull validation can result in a lot of text being printed to a users terminal. Given this, I wanted to avoid "hiding" an error in the flood of validation results. If _any_ CR document is invalid, an error message will be returned and no validations will run. It'll be obvious what failed and how to fix it.