### PR TITLE
refactor: split ConfigureOrCheckCommand into multiple functions

### DIFF
--- a/cmd/validator.go
+++ b/cmd/validator.go
@@ -138,7 +138,7 @@ For more information about validator, see: https://github.com/validator-labs/val
 			if err := c.Save(""); err != nil {
 				return err
 			}
-			if err := validator.ConfigureOrCheckCommand(c, tc); err != nil {
+			if err := validator.ConfigureCommand(c, tc); err != nil {
 				return fmt.Errorf("failed to configure and apply validator rules: %w", err)
 			}
 			return nil
@@ -197,7 +197,7 @@ For more information about validator, see: https://github.com/validator-labs/val
 			if err := c.Save(""); err != nil {
 				return err
 			}
-			if err := validator.ConfigureOrCheckCommand(c, tc); err != nil {
+			if err := validator.CheckCommand(c, tc); err != nil {
 				if errors.Is(err, validator.ErrValidationFailed{}) {
 					cmd.SilenceUsage = true
 				}

--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -206,12 +206,7 @@ func ConfigureCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 		return nil
 	}
 
-	ok, invalidPlugins := vc.EnabledPluginsHaveRules()
-	if !ok {
-		log.FatalCLI("invalid validator configuration", "error",
-			fmt.Sprintf("the following plugins are enabled, but have no rules configured: %v", invalidPlugins),
-		)
-	}
+	ensurePluginsHaveRules(vc)
 
 	// upgrade the validator helm release so that plugin rule secrets
 	// are created, e.g., OCI registry secrets, Network basic auth secrets, etc.
@@ -254,12 +249,7 @@ func CheckCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 		return nil
 	}
 
-	ok, invalidPlugins := vc.EnabledPluginsHaveRules()
-	if !ok {
-		log.FatalCLI("invalid validator configuration", "error",
-			fmt.Sprintf("the following plugins are enabled, but have no rules configured: %v", invalidPlugins),
-		)
-	}
+	ensurePluginsHaveRules(vc)
 
 	return executePlugins(c, toPluginSpecs(vc), vc.SinkConfig)
 }
@@ -309,6 +299,17 @@ func configureValidatorConfig(c *cfg.Config, tc *cfg.TaskConfig) (*components.Va
 	}
 
 	return vc, nil
+}
+
+// ensurePluginsHaveRules checks if enabled plugins have rules configured.
+// If no rules are configured for an enabled plugin, the function exits with an error.
+func ensurePluginsHaveRules(vc *components.ValidatorConfig) {
+	ok, invalidPlugins := vc.EnabledPluginsHaveRules()
+	if !ok {
+		log.FatalCLI("invalid validator configuration", "error",
+			fmt.Sprintf("the following plugins are enabled, but have no rules configured: %v", invalidPlugins),
+		)
+	}
 }
 
 func readPluginSpecs(path string) ([]plugins.PluginSpec, error) {

--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -159,7 +159,7 @@ func InstallValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 		if !configProvided {
 			tc.Reconfigure = true
 		}
-		if err := ConfigureOrCheckCommand(c, tc); err != nil {
+		if err := ConfigureCommand(c, tc); err != nil {
 			return err
 		}
 	}
@@ -178,7 +178,7 @@ func InstallValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 		if !configProvided {
 			tc.Reconfigure = true
 		}
-		if err := ConfigureOrCheckCommand(c, tc); err != nil {
+		if err := ConfigureCommand(c, tc); err != nil {
 			return err
 		}
 	}
@@ -195,64 +195,11 @@ func InstallValidatorCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 	return nil
 }
 
-// ConfigureOrCheckCommand configures and applies/executes validator plugin rules
-// nolint:dupl
-func ConfigureOrCheckCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
-	var vc *components.ValidatorConfig
-	var err error
-	var saveConfig bool
-
-	if tc.CustomResources != "" && tc.Direct {
-		pluginSpecs, err := readPluginSpecs(tc.CustomResources)
-		if err != nil {
-			return err
-		}
-
-		if len(pluginSpecs) == 0 {
-			log.InfoCLI("No plugin rule custom resources found in %s", tc.CustomResources)
-			return nil
-		}
-
-		return executePlugins(c, pluginSpecs, nil)
-	}
-
-	if !tc.Reconfigure {
-		// Silent Mode
-		vc, err = components.NewValidatorFromConfig(tc)
-		if err != nil {
-			return errors.Wrap(err, "failed to load validator configuration file")
-		}
-		if tc.UpdatePasswords {
-			log.Header("Updating plugin credentials in validator configuration file")
-			if err := validator.UpdateValidatorPluginCredentials(vc, tc); err != nil {
-				return err
-			}
-			saveConfig = true
-		}
-	} else {
-		// Interactive mode
-		if tc.Direct && tc.ConfigFile == "" {
-			vc = components.NewValidatorConfig()
-			tc.ConfigFile = filepath.Join(c.RunLoc, cfg.ValidatorConfigFile)
-		} else {
-			vc, err = components.NewValidatorFromConfig(tc)
-			if err != nil {
-				return errors.Wrap(err, "failed to load validator configuration file")
-			}
-		}
-		if err := validator.ReadValidatorPluginConfig(c, tc, vc); err != nil {
-			return errors.Wrap(err, "failed to configure validator plugin(s)")
-		}
-		saveConfig = true
-	}
-
-	// save / print validator config file
-	if saveConfig {
-		if err := components.SaveValidatorConfig(vc, tc); err != nil {
-			return err
-		}
-	} else {
-		log.InfoCLI("validator configuration file: %s", tc.ConfigFile)
+// ConfigureCommand configures and applies validator plugin rules
+func ConfigureCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
+	vc, err := configureValidatorConfig(c, tc)
+	if err != nil {
+		return err
 	}
 
 	if tc.CreateConfigOnly || tc.UpdatePasswords {
@@ -264,10 +211,6 @@ func ConfigureOrCheckCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 		log.FatalCLI("invalid validator configuration", "error",
 			fmt.Sprintf("the following plugins are enabled, but have no rules configured: %v", invalidPlugins),
 		)
-	}
-
-	if tc.Direct {
-		return executePlugins(c, toPluginSpecs(vc), vc.SinkConfig)
 	}
 
 	// upgrade the validator helm release so that plugin rule secrets
@@ -284,6 +227,88 @@ func ConfigureOrCheckCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
 		return err
 	}
 	return nil
+}
+
+// CheckCommand configures and executes validator plugin rules
+func CheckCommand(c *cfg.Config, tc *cfg.TaskConfig) error {
+	if tc.CustomResources != "" {
+		pluginSpecs, err := readPluginSpecs(tc.CustomResources)
+		if err != nil {
+			return err
+		}
+
+		if len(pluginSpecs) == 0 {
+			log.InfoCLI("No plugin rule custom resources found in %s", tc.CustomResources)
+			return nil
+		}
+
+		return executePlugins(c, pluginSpecs, nil)
+	}
+
+	vc, err := configureValidatorConfig(c, tc)
+	if err != nil {
+		return err
+	}
+
+	if tc.CreateConfigOnly || tc.UpdatePasswords {
+		return nil
+	}
+
+	ok, invalidPlugins := vc.EnabledPluginsHaveRules()
+	if !ok {
+		log.FatalCLI("invalid validator configuration", "error",
+			fmt.Sprintf("the following plugins are enabled, but have no rules configured: %v", invalidPlugins),
+		)
+	}
+
+	return executePlugins(c, toPluginSpecs(vc), vc.SinkConfig)
+}
+
+func configureValidatorConfig(c *cfg.Config, tc *cfg.TaskConfig) (*components.ValidatorConfig, error) {
+	var vc *components.ValidatorConfig
+	var err error
+	var saveConfig bool
+
+	if !tc.Reconfigure {
+		// Silent Mode
+		vc, err = components.NewValidatorFromConfig(tc)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to load validator configuration file")
+		}
+		if tc.UpdatePasswords {
+			log.Header("Updating plugin credentials in validator configuration file")
+			if err := validator.UpdateValidatorPluginCredentials(vc, tc); err != nil {
+				return nil, err
+			}
+			saveConfig = true
+		}
+	} else {
+		// Interactive mode
+		if tc.Direct && tc.ConfigFile == "" {
+			vc = components.NewValidatorConfig()
+			tc.ConfigFile = filepath.Join(c.RunLoc, cfg.ValidatorConfigFile)
+		} else {
+			vc, err = components.NewValidatorFromConfig(tc)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to load validator configuration file")
+			}
+		}
+		if err := validator.ReadValidatorPluginConfig(c, tc, vc); err != nil {
+			return nil, errors.Wrap(err, "failed to configure validator plugin(s)")
+		}
+		saveConfig = true
+	}
+
+	// save / print validator config file
+	if saveConfig {
+		if err := components.SaveValidatorConfig(vc, tc); err != nil {
+			return nil, err
+		}
+	} else {
+		log.InfoCLI("validator configuration file: %s", tc.ConfigFile)
+	}
+
+	return vc, nil
 }
 
 func readPluginSpecs(path string) ([]plugins.PluginSpec, error) {

--- a/pkg/config/versions.go
+++ b/pkg/config/versions.go
@@ -4,7 +4,7 @@ package config
 var ValidatorChartVersions = map[string]string{
 	Validator:              "v0.1.11",
 	ValidatorPluginAws:     "v0.1.7",
-	ValidatorPluginAzure:   "v0.0.20",
+	ValidatorPluginAzure:   "v0.0.21",
 	ValidatorPluginMaas:    "v0.0.12",
 	ValidatorPluginNetwork: "v0.1.0",
 	ValidatorPluginOci:     "v0.3.3",

--- a/tests/integration/validatorctl/testcases/data/validator.yaml
+++ b/tests/integration/validatorctl/testcases/data/validator.yaml
@@ -289,7 +289,7 @@ azurePlugin:
     chart:
       name: validator-plugin-azure
       repository: validator-plugin-azure
-      version: v0.0.20
+      version: v0.0.21
       insecureSkipVerify: true
     values: ""
   tenantId: d551b7b1-78ae-43df-9d61-4935c843a454


### PR DESCRIPTION
## Issue
N/A

## Description
Breaks the `ConfigureOrCheckCommand` function down into a `ConfigureCommand` function and a `CheckCommand` function. Also introduces a new `configureValidatorConfig` helper function.

With this change, the cognitive load of modifying either the `ConfigureCommand` or `CheckCommand` functions should be reduced because we no longer need to keep both direct evaluation and continuous evaluation in mind.
