### PR TITLE
fix: ignore nil errors in validationResponseOk

### DIFF
--- a/pkg/cmd/validator/validator.go
+++ b/pkg/cmd/validator/validator.go
@@ -873,6 +873,9 @@ func validationResponseOk(expected int, vr types.ValidationResponse, log logr.Lo
 	var hasRuleError, hasResultCountError, hasValidationError bool
 
 	for _, err := range vr.ValidationRuleErrors {
+		if err == nil {
+			continue
+		}
 		log.V(0).Info("validation rule failed: unexpected error",
 			"error", err,
 		)


### PR DESCRIPTION
## Issue
N/A

## Description
We pre-populate `ValidationRuleErrors` with nils and update them by index in `Finalize`. Therefore we need to ignore nils 🤦🏼 
