### PR TITLE
chore: update plugin versions

### DIFF
--- a/pkg/config/versions.go
+++ b/pkg/config/versions.go
@@ -3,7 +3,7 @@ package config
 // ValidatorChartVersions is a map of validator component names to their respective versions
 var ValidatorChartVersions = map[string]string{
 	Validator:              "v0.1.12",
-	ValidatorPluginAws:     "v0.1.7",
+	ValidatorPluginAws:     "v0.1.8",
 	ValidatorPluginAzure:   "v0.0.22",
 	ValidatorPluginMaas:    "v0.0.12",
 	ValidatorPluginNetwork: "v0.1.0",

--- a/tests/integration/validatorctl/testcases/data/validator.yaml
+++ b/tests/integration/validatorctl/testcases/data/validator.yaml
@@ -59,7 +59,7 @@ awsPlugin:
     chart:
       name: validator-plugin-aws
       repository: validator-plugin-aws
-      version: v0.1.7
+      version: v0.1.8
     values: ""
   accessKeyId: a0XCQd+Emx7/bwAaTyY13ipTRychb4MiQw==
   secretAccessKey: IrGIW8FPVuOxVDRWQUdTa22SDf1MQ2PBw0kdngVq+w==


### PR DESCRIPTION
Uses `make reviewable` to update plugins to the latest version. We do not yet have this automated.