### PR TITLE
fix: param name of util function (for linter)

### DIFF
--- a/pkg/config/versions.go
+++ b/pkg/config/versions.go
@@ -2,9 +2,9 @@ package config
 
 // ValidatorChartVersions is a map of validator component names to their respective versions
 var ValidatorChartVersions = map[string]string{
-	Validator:              "v0.1.12",
-	ValidatorPluginAws:     "v0.1.8",
-	ValidatorPluginAzure:   "v0.0.22",
+	Validator:              "v0.1.13",
+	ValidatorPluginAws:     "v0.1.9",
+	ValidatorPluginAzure:   "v0.0.23",
 	ValidatorPluginMaas:    "v0.0.12",
 	ValidatorPluginNetwork: "v0.1.0",
 	ValidatorPluginOci:     "v0.3.3",

--- a/pkg/utils/string/string.go
+++ b/pkg/utils/string/string.go
@@ -28,8 +28,8 @@ func MultiTrim(str string, prefixes, suffixes []string) string {
 
 // RandStr generates a random string of a given length, which is the first
 // N chars of a UUID of the form: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx, per RFC4122.
-func RandStr(len int) string {
-	return uuid.NewString()[:len]
+func RandStr(strLen int) string {
+	return uuid.NewString()[:strLen]
 }
 
 // IsDevVersion checks if a given CLI version is a development version.

--- a/tests/integration/validatorctl/testcases/data/validator.yaml
+++ b/tests/integration/validatorctl/testcases/data/validator.yaml
@@ -5,7 +5,7 @@ helmRelease:
   chart:
     name: validator
     repository: validator
-    version: v0.1.12
+    version: v0.1.13
   values: ""
 helmReleaseSecret:
   name: validator-helm-release-validator
@@ -59,7 +59,7 @@ awsPlugin:
     chart:
       name: validator-plugin-aws
       repository: validator-plugin-aws
-      version: v0.1.8
+      version: v0.1.9
     values: ""
   accessKeyId: a0XCQd+Emx7/bwAaTyY13ipTRychb4MiQw==
   secretAccessKey: IrGIW8FPVuOxVDRWQUdTa22SDf1MQ2PBw0kdngVq+w==
@@ -289,7 +289,7 @@ azurePlugin:
     chart:
       name: validator-plugin-azure
       repository: validator-plugin-azure
-      version: v0.0.22
+      version: v0.0.23
       insecureSkipVerify: true
     values: ""
   tenantId: d551b7b1-78ae-43df-9d61-4935c843a454


### PR DESCRIPTION
## Description
Our Revive linter is disallowing the name `len` for a parameter. We made this code a while ago, but the linter is raising the issue now. It may be an update to the linter. This changes the parameter name to resolve it.

Also applies changes from latest `make reviewable` so that the PR can be merged.