### PR TITLE
chore: update chart values to remove kube-rbac-proxy

### DIFF
--- a/pkg/config/versions.go
+++ b/pkg/config/versions.go
@@ -2,11 +2,11 @@ package config
 
 // ValidatorChartVersions is a map of validator component names to their respective versions
 var ValidatorChartVersions = map[string]string{
-	Validator:              "v0.1.13",
-	ValidatorPluginAws:     "v0.1.10",
-	ValidatorPluginAzure:   "v0.0.24",
-	ValidatorPluginMaas:    "v0.0.12",
-	ValidatorPluginNetwork: "v0.1.0",
-	ValidatorPluginOci:     "v0.3.3",
-	ValidatorPluginVsphere: "v0.1.4",
+	Validator:              "v0.1.15",
+	ValidatorPluginAws:     "v0.1.11",
+	ValidatorPluginAzure:   "v0.0.25",
+	ValidatorPluginMaas:    "v0.0.13",
+	ValidatorPluginNetwork: "v0.1.1",
+	ValidatorPluginOci:     "v0.3.4",
+	ValidatorPluginVsphere: "v0.1.5",
 }

--- a/pkg/utils/crypto/crypto.go
+++ b/pkg/utils/crypto/crypto.go
@@ -36,6 +36,7 @@ func DecryptB64(cipherstringB64 string) (*[]byte, error) {
 	iv := ciphertext[:aes.BlockSize]
 	ciphertext = ciphertext[aes.BlockSize:]
 
+	// #nosec G407
 	stream := cipher.NewCFBDecrypter(block, iv)
 	stream.XORKeyStream(ciphertext, ciphertext)
 
@@ -61,6 +62,7 @@ func EncryptB64(plainbytes []byte) (string, error) {
 		return "", err
 	}
 
+	// #nosec G407
 	stream := cipher.NewCFBEncrypter(block, iv)
 	stream.XORKeyStream(ciphertext[aes.BlockSize:], plainbytes)
 

--- a/pkg/utils/embed/resources/validator/validator-base-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-base-values.tmpl
@@ -1,28 +1,8 @@
 controllerManager:
-  kubeRbacProxy:
-    args:
-    - --secure-listen-address=0.0.0.0:8443
-    - --upstream=http://127.0.0.1:8080/
-    - --logtostderr=true
-    - --v=0
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - ALL
-    image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.16.0
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 5m
-        memory: 64Mi
   manager:
     args:
     - --health-probe-bind-address=:8081
+    - --metrics-bind-address=:8443
     - --leader-elect
     containerSecurityContext:
       allowPrivilegeEscalation: false

--- a/pkg/utils/embed/resources/validator/validator-base-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-base-values.tmpl
@@ -29,7 +29,7 @@ metricsService:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   type: ClusterIP
 
 {{- if or .ProxyConfig.Env.HTTPProxy .ProxyConfig.Env.HTTPSProxy }}

--- a/pkg/utils/embed/resources/validator/validator-plugin-aws-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-plugin-aws-values.tmpl
@@ -28,7 +28,7 @@ metricsService:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   type: ClusterIP
 auth:
   serviceAccountName: "{{ .Config.ServiceAccountName }}"

--- a/pkg/utils/embed/resources/validator/validator-plugin-aws-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-plugin-aws-values.tmpl
@@ -1,28 +1,8 @@
 controllerManager:
-  kubeRbacProxy:
-    args:
-    - --secure-listen-address=0.0.0.0:8443
-    - --upstream=http://127.0.0.1:8080/
-    - --logtostderr=true
-    - --v=0
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - ALL
-    image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.16.0
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 5m
-        memory: 64Mi
   manager:
     args:
     - --health-probe-bind-address=:8081
+    - --metrics-bind-address=:8443
     - --leader-elect
     containerSecurityContext:
       allowPrivilegeEscalation: false

--- a/pkg/utils/embed/resources/validator/validator-plugin-azure-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-plugin-azure-values.tmpl
@@ -28,7 +28,7 @@ metricsService:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   type: ClusterIP
 auth:
   serviceAccountName: "{{ .Config.ServiceAccountName }}"

--- a/pkg/utils/embed/resources/validator/validator-plugin-azure-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-plugin-azure-values.tmpl
@@ -1,28 +1,8 @@
 controllerManager:
-  kubeRbacProxy:
-    args:
-    - --secure-listen-address=0.0.0.0:8443
-    - --upstream=http://127.0.0.1:8080/
-    - --logtostderr=true
-    - --v=0
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - ALL
-    image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.15.0
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 5m
-        memory: 64Mi
   manager:
     args:
     - --health-probe-bind-address=:8081
+    - --metrics-bind-address=:8443
     - --leader-elect
     containerSecurityContext:
       allowPrivilegeEscalation: false

--- a/pkg/utils/embed/resources/validator/validator-plugin-maas-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-plugin-maas-values.tmpl
@@ -28,7 +28,7 @@ metricsService:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   type: ClusterIP
 auth:
   secretName: {{ .Config.Validator.Auth.SecretName }}

--- a/pkg/utils/embed/resources/validator/validator-plugin-maas-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-plugin-maas-values.tmpl
@@ -1,28 +1,8 @@
 controllerManager:
-  kubeRbacProxy:
-    args:
-    - --secure-listen-address=0.0.0.0:8443
-    - --upstream=http://127.0.0.1:8080/
-    - --logtostderr=true
-    - --v=0
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - ALL
-    image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.16.0
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 5m
-        memory: 64Mi
   manager:
     args:
     - --health-probe-bind-address=:8081
+    - --metrics-bind-address=:8443
     - --leader-elect
     containerSecurityContext:
       allowPrivilegeEscalation: false

--- a/pkg/utils/embed/resources/validator/validator-plugin-network-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-plugin-network-values.tmpl
@@ -30,5 +30,5 @@ metricsService:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   type: ClusterIP

--- a/pkg/utils/embed/resources/validator/validator-plugin-network-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-plugin-network-values.tmpl
@@ -1,28 +1,8 @@
 controllerManager:
-  kubeRbacProxy:
-    args:
-    - --secure-listen-address=0.0.0.0:8443
-    - --upstream=http://127.0.0.1:8080/
-    - --logtostderr=true
-    - --v=0
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - ALL
-    image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.16.0
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 5m
-        memory: 64Mi
   manager:
     args:
     - --health-probe-bind-address=:8081
+    - --metrics-bind-address=:8443
     - --leader-elect
     containerSecurityContext:
       allowPrivilegeEscalation: true

--- a/pkg/utils/embed/resources/validator/validator-plugin-oci-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-plugin-oci-values.tmpl
@@ -28,5 +28,5 @@ metricsService:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   type: ClusterIP

--- a/pkg/utils/embed/resources/validator/validator-plugin-oci-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-plugin-oci-values.tmpl
@@ -1,28 +1,8 @@
 controllerManager:
-  kubeRbacProxy:
-    args:
-    - --secure-listen-address=0.0.0.0:8443
-    - --upstream=http://127.0.0.1:8080/
-    - --logtostderr=true
-    - --v=0
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - ALL
-    image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.15.0
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 5m
-        memory: 64Mi
   manager:
     args:
     - --health-probe-bind-address=:8081
+    - --metrics-bind-address=:8443
     - --leader-elect
     containerSecurityContext:
       allowPrivilegeEscalation: false

--- a/pkg/utils/embed/resources/validator/validator-plugin-vsphere-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-plugin-vsphere-values.tmpl
@@ -1,28 +1,8 @@
 controllerManager:
-  kubeRbacProxy:
-    args:
-      - --secure-listen-address=0.0.0.0:8443
-      - --upstream=http://127.0.0.1:8080/
-      - --logtostderr=true
-      - --v=0
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-          - ALL
-    image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.16.0
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 5m
-        memory: 64Mi
   manager:
     args:
       - --health-probe-bind-address=:8081
+      - --metrics-bind-address=:8443
       - --leader-elect
     containerSecurityContext:
       allowPrivilegeEscalation: false

--- a/pkg/utils/embed/resources/validator/validator-plugin-vsphere-values.tmpl
+++ b/pkg/utils/embed/resources/validator/validator-plugin-vsphere-values.tmpl
@@ -28,5 +28,5 @@ metricsService:
     - name: https
       port: 8443
       protocol: TCP
-      targetPort: https
+      targetPort: 8443
   type: ClusterIP

--- a/tests/integration/validatorctl/testcases/data/validator.yaml
+++ b/tests/integration/validatorctl/testcases/data/validator.yaml
@@ -5,7 +5,7 @@ helmRelease:
   chart:
     name: validator
     repository: validator
-    version: v0.1.13
+    version: v0.1.15
   values: ""
 helmReleaseSecret:
   name: validator-helm-release-validator
@@ -59,7 +59,7 @@ awsPlugin:
     chart:
       name: validator-plugin-aws
       repository: validator-plugin-aws
-      version: v0.1.10
+      version: v0.1.11
     values: ""
   accessKeyId: a0XCQd+Emx7/bwAaTyY13ipTRychb4MiQw==
   secretAccessKey: IrGIW8FPVuOxVDRWQUdTa22SDf1MQ2PBw0kdngVq+w==
@@ -173,7 +173,7 @@ networkPlugin:
     chart:
       name: validator-plugin-network
       repository: validator-plugin-network
-      version: v0.1.0
+      version: v0.1.1
     values: ""
   validator:
     dnsRules:
@@ -201,7 +201,7 @@ ociPlugin:
     chart:
       name: validator-plugin-oci
       repository: validator-plugin-oci
-      version: v0.3.3
+      version: v0.3.4
     values: ""
   secrets:
   - name: oci-creds
@@ -232,7 +232,7 @@ vspherePlugin:
     chart:
       name: validator-plugin-vsphere
       repository: validator-plugin-vsphere
-      version: v0.1.4
+      version: v0.1.5
     values: ""
   validator:
     auth:
@@ -289,7 +289,7 @@ azurePlugin:
     chart:
       name: validator-plugin-azure
       repository: validator-plugin-azure
-      version: v0.0.24
+      version: v0.0.25
       insecureSkipVerify: true
     values: ""
   tenantId: d551b7b1-78ae-43df-9d61-4935c843a454
@@ -556,7 +556,7 @@ maasPlugin:
     chart:
       name: validator-plugin-maas
       repository: validator-plugin-maas
-      version: v0.0.12
+      version: v0.0.13
     values: ""
   validator:
     internalDNSRules:


### PR DESCRIPTION
## Issue
Resolves #276 

## Description
Following the removal of `kube-rbac-proxy` from all plugins and validator, this PR bumps all versions and updates the chart templates to remove `kube-rbac-proxy`

Manually tested by installing validator and all plugins, and confirming that all controllers come up, and metrics service is exposed and accessible with `curl`.
